### PR TITLE
Use a clearer voice across the pkgdown site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,17 @@
 [![Codecov test coverage](https://codecov.io/gh/JamesHWade/graft/graph/badge.svg)](https://app.codecov.io/gh/JamesHWade/graft)
 <!-- badges: end -->
 
-graft is for R workflows where knowledge needs more structure than rows but
-should still behave like data. It keeps domain records, claims, sources, and
-evidence in ordinary relational tables while enforcing a versioned semantic
-contract around identity, validation, provenance, and retrieval.
+graft is an R package for storing schema-defined knowledge in DuckDB. A store
+can contain domain records, claims about those records, sources, and evidence
+that links a claim to a specific source location.
 
-Use graft when knowledge accumulates across research or agentic runs and you
-need to answer not only *which records match?*, but also *which claim is this,
-what supports or challenges it, and which schema gave it meaning?*
+A LinkML schema defines the record classes, fields, identifiers, validation
+rules, and graph projections. `kg_compile_schema()` resolves that schema into a
+`.graft.json` manifest, which graft uses to initialize and query the database.
 
 Start with the [getting started
-guide](https://jameshwade.github.io/graft/articles/getting-started.html) for the
-package's motivation, mental model, and a complete source-backed workflow.
-
-graft compiles a LinkML semantic contract into a portable JSON manifest that
-describes concrete record classes, relational tables, identity policies,
-validation invariants, and graph projections.
+guide](https://jameshwade.github.io/graft/articles/getting-started.html) to
+build a small store and query its records, claims, and evidence.
 
 Python and `linkml-runtime` are required only to compile a schema. Loading and
 inspecting a committed manifest is pure R/JSON. The manifest drives DuckDB
@@ -46,9 +41,9 @@ graph <- kg_neighbors(
 )
 ```
 
-All collected retrieval and graph operations are bounded and report
-truncation. For model-assisted retrieval, `kg_tools()` exposes six read-only
-structured tools over the same bounded APIs:
+Functions that collect records or graph results require a limit and report
+whether the result was truncated. `kg_tools()` exposes six of the same
+read-only queries as ellmer tools:
 
 ```r
 chat <- ellmer::chat_anthropic()

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,11 +24,11 @@ template:
     navbar-dark-bg: "#12362D"
 
 home:
-  title: "graft: Evidence-backed knowledge for R"
+  title: "graft: Schema-defined knowledge stores for R"
   description: >
-    A table-native R knowledge layer that compiles LinkML contracts into
-    portable DuckDB stores for typed records, claims, citations, identity,
-    graph projections, and bounded model-assisted retrieval.
+    Compile LinkML schemas into manifests that define DuckDB tables,
+    identifiers, validation rules, claims, evidence, and graph projections,
+    then read and write those stores from R.
   sidebar:
     structure: [links, license, authors, dev]
 
@@ -55,16 +55,15 @@ footer:
 articles:
   - title: Start here
     desc: >
-      Learn why graft exists and follow a complete source-backed workflow from
-      a compiled domain contract to bounded retrieval.
+      Build a small materials store from an included schema, then add records,
+      a claim, a source, and evidence and query them from R.
     contents:
       - getting-started
 
 reference:
   - title: Schema
     desc: >
-      Compile, load, compare, and inspect the semantic contract that drives a
-      graft store.
+      Compile and inspect LinkML schemas and their generated manifests.
   - contents:
       - kg_compile_schema
       - kg_schema
@@ -75,8 +74,7 @@ reference:
       - kg_schema_info
   - title: Store lifecycle
     desc: >
-      Create and inspect ownership-aware DuckDB stores protected by structural
-      schema fingerprints.
+      Open, initialize, inspect, and close a DuckDB store.
   - contents:
       - kg_connect_duckdb
       - kg_init
@@ -85,8 +83,7 @@ reference:
       - kg_capabilities
   - title: Ingestion and validation
     desc: >
-      Validate and atomically reconcile typed records with batch provenance and
-      idempotent replay.
+      Validate and write records in batches with provenance and idempotency.
   - contents:
       - kg_batch
       - kg_ingest
@@ -95,7 +92,7 @@ reference:
       - kg_validate_data
   - title: Records and identity
     desc: >
-      Retrieve lazy class tables, hydrate records, and resolve exact external
+      Read records, search declared text fields, and resolve external
       identifiers.
   - contents:
       - kg_records
@@ -106,16 +103,15 @@ reference:
       - kg_unresolved
   - title: Claims and evidence
     desc: >
-      Inspect narrative and semantic assertions together with their stored
-      supporting or challenging evidence.
+      Inspect claims and the stored sources and locations that support or
+      challenge them.
   - contents:
       - kg_claims
       - kg_evidence
       - kg_competing_claims
   - title: Graph projections
     desc: >
-      Traverse deterministic, bounded semantic and provenance projections over
-      the relational store.
+      Inspect graph nodes and edges or traverse a limited neighborhood.
   - contents:
       - kg_nodes
       - kg_edges
@@ -124,15 +120,15 @@ reference:
       - kg_subgraph
   - title: Structured access
     desc: >
-      Describe the active knowledge contract and expose validated, bounded
-      access to applications and language models.
+      Inspect the retrieval contract, run field-and-filter queries, and create
+      ellmer tools.
   - contents:
       - kg_context
       - kg_select
       - kg_tools
   - title: Tempest integration
     desc: >
-      Connect mapped Tempest domain records while preserving the current typed
-      artifact-store boundary.
+      Write mapped Tempest records and inspect the current artifact-store
+      adapter.
   - contents:
       - tempest_artifact_store_graft

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -1,134 +1,142 @@
 # graft
 
 <div class="graft-hero">
-<p class="graft-eyebrow">Table-native knowledge for R</p>
-<h2 data-toc-skip>Keep knowledge connected to its evidence.</h2>
+<p class="graft-eyebrow">An R package for LinkML and DuckDB</p>
+<h2 data-toc-skip>Schema-defined knowledge in DuckDB.</h2>
 <p class="graft-hero-copy">
-    graft turns a LinkML contract into a portable DuckDB knowledge layer where
-    records, claims, identity, and citations remain inspectable from R and
-    model-assisted workflows.
+    graft compiles a LinkML schema into a JSON manifest. The manifest defines
+    records, tables, identifiers, validation rules, and graph projections.
+    graft uses it to create and query a DuckDB database from R.
 </p>
 <div class="graft-actions">
 <a class="btn btn-primary" href="articles/getting-started.html">Get started</a>
 <a class="btn btn-outline-secondary" href="https://github.com/JamesHWade/graft">
-      View on GitHub
+      View source
 </a>
 </div>
 <div class="graft-tags" aria-label="Core package characteristics">
-<span class="graft-tag">LinkML contract</span>
-<span class="graft-tag">DuckDB runtime</span>
-<span class="graft-tag">Evidence-backed claims</span>
-<span class="graft-tag">Bounded retrieval</span>
+<span class="graft-tag">LinkML schemas</span>
+<span class="graft-tag">DuckDB storage</span>
+<span class="graft-tag">DBI and dbplyr</span>
+<span class="graft-tag">Optional ellmer tools</span>
 </div>
 </div>
 
-## Why graft?
+## What graft adds
 
 <p class="graft-section-lead">
-Research and agentic systems rarely need only another table. They need to know
-whether two observations refer to the same thing, which source supports a
-claim, what changed between runs, and whether a query stayed inside the active
-semantic contract.
+A database schema describes columns and types. It does not usually say which
+fields identify the same record across runs, how a claim relates to its
+evidence, or which relationships belong in a graph. graft records those
+decisions in a LinkML schema and applies them when data are written and read.
 </p>
 
 <div class="graft-card-grid">
 <div class="graft-card">
 <div class="graft-card-mark" aria-hidden="true">01</div>
-<h3>Contract first</h3>
+<h3>Define the domain</h3>
 <p>
-      Compile a LinkML domain schema into a portable, fingerprinted manifest
-      that drives tables, validation, identity, and graph projections.
+      Describe materials, sources, claims, evidence, or other project-specific
+      records as LinkML classes.
 </p>
 </div>
 <div class="graft-card">
 <div class="graft-card-mark" aria-hidden="true">02</div>
-<h3>Evidence stays attached</h3>
+<h3>Generate the manifest</h3>
 <p>
-      Keep narrative and semantic claims distinct, then connect them to exact
-      stored sources, locators, excerpts, and support relationships.
+      Resolve the schema once with <code>kg_compile_schema()</code>. Commit the
+      generated <code>.graft.json</code> file with the project.
 </p>
 </div>
 <div class="graft-card">
 <div class="graft-card-mark" aria-hidden="true">03</div>
-<h3>Retrieval stays bounded</h3>
+<h3>Use the store from R</h3>
 <p>
-      Give analysts and language models structured access without arbitrary SQL
-      or silent unbounded collection.
+      Write validated records to DuckDB, query lazy dbplyr tables, and inspect
+      claims, evidence, identifiers, and graph neighborhoods.
 </p>
 </div>
 </div>
 
-## From schema to answer
+## The basic workflow
 
 <div class="graft-flow" aria-label="The four-stage graft workflow">
 <div class="graft-flow-step">
 <span class="graft-flow-number">01</span>
-<strong>Model the domain</strong>
-<span>Extend graft's core LinkML record roles.</span>
+<strong>Write a schema</strong>
+<span>Extend the core LinkML record classes.</span>
 </div>
 <div class="graft-flow-step">
 <span class="graft-flow-number">02</span>
-<strong>Compile the contract</strong>
-<span>Commit the resolved <code>.graft.json</code> manifest.</span>
+<strong>Compile it</strong>
+<span>Create a resolved <code>.graft.json</code> manifest.</span>
 </div>
 <div class="graft-flow-step">
 <span class="graft-flow-number">03</span>
-<strong>Ingest atomically</strong>
-<span>Reconcile identity and preserve batch provenance.</span>
+<strong>Initialize a store</strong>
+<span>Create the declared tables and graph views in DuckDB.</span>
 </div>
 <div class="graft-flow-step">
 <span class="graft-flow-number">04</span>
-<strong>Retrieve safely</strong>
-<span>Use lazy tables, bounded APIs, graphs, or ellmer tools.</span>
+<strong>Read and write records</strong>
+<span>Use dbplyr tables or graft's collected query functions.</span>
 </div>
 </div>
 
-## A familiar R workflow
+## A small example
 
 ```r
 library(graft)
 
-schema <- kg_schema("materials.graft.json")
-store <- kg_connect_duckdb(schema, "knowledge.duckdb")
+manifest <- system.file(
+  "extdata",
+  "materials.graft.json",
+  package = "graft"
+)
+schema <- kg_schema(manifest)
+store <- kg_connect_duckdb(schema, ":memory:")
 kg_init(store)
 
-matches <- kg_find(store, "LLDPE crystallinity", limit = 10)
-record <- kg_get(store, matches$id[[1]])
-claims <- kg_claims(store, record$id)
+kg_classes(schema)
+kg_slots(schema, "Claim")
 ```
 
-The manifest is compiled once. Loading it, managing DuckDB, and retrieving
-knowledge run entirely in R.
+Python and `linkml-runtime` are needed to compile a schema. Loading a compiled
+manifest and using a store run entirely in R.
+
+## Query interfaces
 
 <div class="graft-audience-grid">
 <div class="graft-audience">
-<h3>For R users</h3>
+<h3>R and dbplyr</h3>
 <p>
-      Work with DBI and lazy dbplyr tables, exact identifier lookup, hydrated
-      records, stored citations, and bounded graph neighborhoods.
+      <code>kg_records()</code> returns a lazy dbplyr table.
+      <code>kg_find()</code>, <code>kg_get()</code>, and the graph helpers
+      return collected results with explicit limits.
 </p>
 </div>
 <div class="graft-audience">
-<h3>For model-assisted workflows</h3>
+<h3>ellmer tools</h3>
 <p>
-      Expose six read-only ellmer tools over the same manifest-controlled APIs,
-      with limits, truncation state, and schema digests in every result.
+      <code>kg_tools()</code> creates six read-only tools for one store. The
+      tools accept structured arguments rather than SQL and report truncation
+      state and the active schema digest.
 </p>
 </div>
 </div>
 
 <div class="graft-cta">
-<h2 data-toc-skip>Build the first complete workflow</h2>
+<h2 data-toc-skip>Next steps</h2>
 <p>
-    The getting-started guide follows a material from its schema through
-    identity resolution, a source-backed claim, and bounded retrieval.
+    The getting-started guide builds a small materials store, then adds records,
+    a claim, a source, and evidence.
 </p>
 <div class="graft-actions justify-content-center">
 <a class="btn btn-primary" href="articles/getting-started.html">
-      Read the guide
+      Read getting started
 </a>
 <a class="btn btn-outline-secondary" href="reference/index.html">
-      Browse the reference
+      Browse functions
 </a>
 </div>
 </div>

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "Getting started with graft"
 description: >
-  Understand why graft exists and follow a complete materials example from a
-  compiled LinkML contract to a source-backed claim and bounded retrieval.
+  Build a small materials store from a compiled LinkML schema, add a
+  source-backed claim, and query it from R.
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Getting started with graft}
@@ -17,33 +17,32 @@ knitr::opts_chunk$set(
 )
 ```
 
-graft is for R workflows in which knowledge must remain inspectable after it
-has been collected, reconciled, and reused. It keeps domain records, claims,
-sources, and evidence in ordinary relational tables while enforcing a semantic
-contract around them.
+graft stores schema-defined knowledge in DuckDB. A store can contain domain
+records, claims about those records, sources, and evidence that links a claim
+to a location in a source.
 
-This matters when a workflow needs to answer more than "which rows match?" For
-example:
+The schema records decisions that are otherwise easy to spread across
+application code:
 
-- Is this material the same one observed in an earlier run?
-- Is a statement a source-faithful narrative claim or a normalized semantic
-  assertion?
-- Which stored source and exact locator support or challenge the claim?
-- Can an analyst or language model retrieve the answer without accessing
-  arbitrary SQL or silently collecting an unbounded result?
+- which fields identify the same record across runs;
+- which fields are required and how they are validated;
+- whether a statement is narrative or semantic;
+- how claims, sources, and evidence are related; and
+- which relationships are available as graph projections.
 
-graft addresses these questions without requiring a separate graph database.
-It compiles a [LinkML](https://linkml.io/) domain schema into a portable
-manifest, uses that manifest to create and protect a DuckDB store, and exposes
-the stored knowledge through R, dbplyr, bounded graph projections, and optional
-ellmer tools.
+graft expresses these decisions in [LinkML](https://linkml.io/) and compiles
+the schema into a JSON manifest. At runtime, the manifest defines the DuckDB
+tables and the behavior of graft's read and write functions.
 
-## The mental model
+This guide uses the materials schema included with the package. It creates an
+in-memory store, writes a material and a source, adds a claim and its evidence,
+and then queries the result.
+
+## How the pieces fit together
 
 The main workflow is:
 
-> LinkML schema -> compiled `.graft.json` manifest -> DuckDB store -> bounded R
-> and agent-facing retrieval
+> LinkML schema -> compiled `.graft.json` manifest -> DuckDB store -> R queries
 
 Each part has one job:
 
@@ -51,13 +50,13 @@ Each part has one job:
    such as materials, sources, claims, and evidence by extending graft's core
    record roles.
 2. **The compiled manifest is the runtime contract.** It contains the resolved
-   classes, fields, relational mapping, identity rules, validation invariants,
-   graph projections, and schema fingerprints. Commit it with your project.
+   classes, fields, relational mapping, identity rules, validation rules, graph
+   projections, and schema fingerprints. Commit it with your project.
 3. **DuckDB stores the records.** The database remains table-native, portable,
    and available to familiar DBI and dbplyr workflows.
-4. **graft controls knowledge access.** Retrieval is limited to
-   manifest-declared classes and fields. Collected results are explicitly
-   bounded and carry the active schema digest.
+4. **graft applies the contract.** Read and write functions accept only
+   manifest-declared classes and fields. Functions that collect results require
+   explicit limits and report the active schema digest.
 
 Python and `linkml-runtime` are used only for step 2. Loading an existing
 manifest and performing normal storage or retrieval both run entirely in R.
@@ -313,7 +312,7 @@ kg_select(
 )
 ```
 
-## Use graft with a language model
+## Use graft with ellmer
 
 If the `ellmer` package is installed, `kg_tools()` creates six read-only tools
 that capture one initialized store:
@@ -323,15 +322,12 @@ chat <- ellmer::chat_anthropic()
 chat$set_tools(kg_tools(store))
 ```
 
-The tools expose the same manifest-controlled, bounded retrieval surfaces used
-above. They do not accept SQL, file paths, URLs, or network options. Their
-results include truncation metadata and the store's schema digest, so a caller
-can tell whether an answer was based on a complete bounded result and which
-contract shaped it.
+The tools call the same query functions shown above. They do not accept SQL,
+file paths, URLs, or network options. Each result reports its limit, whether it
+was truncated, and the store's schema digest.
 
-graft does not make model output trustworthy by itself. It supplies the
-mechanics for retrieving stored claims and citation material without inventing
-sources or bypassing the domain contract.
+`kg_tools()` does not validate model output. It gives a model read-only access
+to records and evidence that are already present in the store.
 
 ## Bring your own domain
 
@@ -376,18 +372,16 @@ store <- kg_connect_duckdb(schema, "knowledge.duckdb")
 kg_init(store)
 ```
 
-## When graft is a good fit
+## When to use graft
 
-Use graft when domain knowledge accumulates across runs and must preserve
-identity, claims, evidence, and a versioned semantic contract while remaining
-comfortable to query from R.
+Use graft when a project needs to preserve record identity, claims, sources,
+and evidence across runs while keeping the data available through R, DBI, and
+dbplyr.
 
-graft is not a replacement for LinkML schema design, a general-purpose graph
-database, vector similarity search, or source collection. It sits between
-those concerns: producers supply domain records and evidence, LinkML defines
-their meaning, DuckDB stores them as tables, and graft keeps identity,
-provenance, graph projection, and retrieval behavior aligned with the compiled
-contract.
+graft does not design the LinkML schema, collect source material, provide
+vector similarity search, or replace a general-purpose graph database. It
+manages the boundary between schema-defined records and their representation
+in DuckDB.
 
 ```{r cleanup, include = FALSE}
 kg_disconnect(store)


### PR DESCRIPTION
## What changed

- rewrote the pkgdown homepage around concrete package behavior and a small runnable example
- aligned the README and getting-started guide with the same plain, technical voice
- simplified pkgdown metadata and reference-section descriptions
- clarified the Python, DuckDB, dbplyr, and ellmer boundaries

## Why

The existing documentation explained the right concepts but often used abstract or promotional language. This revision starts with what graft consumes, creates, and adds beyond an ordinary database schema.

## Impact

Package users get a clearer path from a LinkML schema to a DuckDB store, with explicit descriptions of lazy queries, collected results, evidence, and optional ellmer tools.

## Validation

- `air format .`
- `pkgdown::build_site(preview = FALSE, new_process = FALSE)`
- `pkgdown::check_pkgdown()`
- rendered-site inspection of the homepage and getting-started guide
- `devtools::check()` — 0 errors, 0 warnings, 0 notes