### PR TITLE
Clarify graft's purpose for R workflow users

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,13 @@
 Package: graft
-Title: A Table-Native Knowledge Layer
+Title: Schema-Defined Knowledge for R Workflows
 Version: 0.0.0.9000
 Authors@R:
     person("James", role = c("aut", "cre"), email = "github@jameshwade.com")
-Description: Compiles LinkML schemas into portable relational manifests for
-    typed, citation-backed knowledge records. Runtime schema inspection is
-    implemented entirely in R; Python is used only during schema compilation.
+Description: Turns records produced by R workflows into consistent, traceable
+    knowledge. A LinkML-derived runtime contract reconciles identity across
+    runs, validates related records, preserves claims with source evidence, and
+    governs bounded retrieval. Stores use embedded DuckDB and remain available
+    through DBI and dbplyr.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 [![Codecov test coverage](https://codecov.io/gh/JamesHWade/graft/graph/badge.svg)](https://app.codecov.io/gh/JamesHWade/graft)
 <!-- badges: end -->
 
-graft is an R package for storing schema-defined knowledge in DuckDB. A store
-can contain domain records, claims about those records, sources, and evidence
-that links a claim to a specific source location.
+graft keeps records produced by R workflows consistent, connected, and
+traceable across runs. It reconciles identities, validates related data as they
+are written, preserves claims with exact source evidence, and provides bounded
+retrieval for analysts, applications, and AI tools.
 
-A LinkML schema defines the record classes, fields, identifiers, validation
-rules, and graph projections. `kg_compile_schema()` resolves that schema into a
-`.graft.json` manifest, which graft uses to initialize and query the database.
+The package puts decisions that often drift across scripts into one versioned
+contract: what each record means, how it is identified, which relationships are
+valid, and what may be retrieved. The contract begins as an ordinary LinkML
+schema and compiles to a portable `.graft.json` manifest.
 
 Start with the [getting started
 guide](https://jameshwade.github.io/graft/articles/getting-started.html) to
@@ -23,9 +25,10 @@ The [examples
 page](https://jameshwade.github.io/graft/articles/examples.html) applies the
 same workflow to chemistry and environmental biology.
 
-Python and `linkml-runtime` are required only to compile a schema. Loading and
-inspecting a committed manifest is pure R/JSON. The manifest drives DuckDB
-storage, validation, identity, retrieval, and graph projections:
+The current storage backend is embedded DuckDB, which keeps a graft store local
+and available through DBI and dbplyr. Python and `linkml-runtime` are required
+only to compile a schema; loading a committed manifest and using a store run in
+R:
 
 ```r
 library(graft)
@@ -39,13 +42,34 @@ schema <- kg_schema(manifest)
 store <- kg_connect_duckdb(schema, ":memory:")
 kg_init(store)
 
-kg_classes(schema)
-kg_slots(schema, "Person")
+kg_ingest(
+  store,
+  kg_batch(
+    producer = "directory-import",
+    source_run_id = "run-42",
+    idempotency_key = "daily-planet-v1"
+  ),
+  list(
+    Organization = data.frame(
+      id = "org:daily-planet",
+      name = "Daily Planet"
+    ),
+    Person = data.frame(
+      id = "person:clark-kent",
+      full_name = "Clark Kent",
+      employed_by = I(list("org:daily-planet"))
+    )
+  )
+)
+
+kg_get(store, "person:clark-kent")
 ```
 
-Functions that collect records or graph results require a limit and report
-whether the result was truncated. `kg_tools()` exposes six of the same
-read-only queries as ellmer tools:
+The batch is atomic, its relationship is validated, and reusing the same
+producer and idempotency key does not create another observation. Functions
+that collect records or graph results require a limit and report whether the
+result was truncated. `kg_tools()` exposes six of the same read-only queries as
+ellmer tools:
 
 ```r
 chat <- ellmer::chat_anthropic()

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,11 +24,10 @@ template:
     navbar-dark-bg: "#12362D"
 
 home:
-  title: "graft: Schema-defined knowledge stores for R"
+  title: "graft: Traceable knowledge for R workflows"
   description: >
-    Compile LinkML schemas into manifests that define DuckDB tables,
-    identifiers, validation rules, claims, evidence, and graph projections,
-    then read and write those stores from R.
+    Keep records consistent across runs, preserve claims with exact evidence,
+    and provide bounded, schema-aware retrieval to analysts and AI tools.
   sidebar:
     structure: [links, license, authors, dev]
 
@@ -58,8 +57,8 @@ footer:
 articles:
   - title: Start here
     desc: >
-      Build a small knowledge store, or start from an ordinary LinkML schema
-      and see how its classes and slots map to DuckDB.
+      Follow one workflow from domain contract to traceable retrieval, or start
+      from an ordinary LinkML schema and see how graft applies it in R.
     contents:
       - getting-started
       - linkml-schema

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -1,12 +1,13 @@
 # graft
 
 <div class="graft-hero">
-<p class="graft-eyebrow">An R package for LinkML and DuckDB</p>
-<h2 data-toc-skip>Schema-defined knowledge in DuckDB.</h2>
+<p class="graft-eyebrow">A knowledge layer for R workflows</p>
+<h2 data-toc-skip>Keep workflow results consistent, connected, and traceable.</h2>
 <p class="graft-hero-copy">
-    graft compiles a LinkML schema into a JSON manifest. The manifest defines
-    records, tables, identifiers, validation rules, and graph projections.
-    graft uses it to create and query a DuckDB database from R.
+    Define what your domain records mean once. graft applies that contract
+    whenever R workflows write or retrieve data&mdash;reconciling identities
+    across runs, validating relationships, preserving claims with exact
+    evidence, and exposing predictable queries to analysts and AI tools.
 </p>
 <div class="graft-actions">
 <a class="btn btn-primary" href="articles/getting-started.html">Get started</a>
@@ -15,75 +16,81 @@
 </a>
 </div>
 <div class="graft-tags" aria-label="Core package characteristics">
-<span class="graft-tag">LinkML schemas</span>
-<span class="graft-tag">DuckDB storage</span>
-<span class="graft-tag">DBI and dbplyr</span>
-<span class="graft-tag">Optional ellmer tools</span>
+<span class="graft-tag">Stable identity</span>
+<span class="graft-tag">Schema-checked ingestion</span>
+<span class="graft-tag">Claims and evidence</span>
+<span class="graft-tag">Bounded retrieval</span>
 </div>
 </div>
 
-## What graft adds
+## When tidy tables are not enough
 
 <p class="graft-section-lead">
-A database schema describes columns and types. It does not usually say which
-fields identify the same record across runs, how a claim relates to its
-evidence, or which relationships belong in a graph. graft records those
-decisions in a LinkML schema and applies them when data are written and read.
+An R workflow can produce tidy tables and still leave hard questions scattered
+across scripts. Is this the same material as last run? Which source supports
+this claim? Is a relationship stated or inferred? What may an automated tool
+retrieve? graft makes those decisions explicit, versioned, and enforceable.
 </p>
 
 <div class="graft-card-grid">
 <div class="graft-card">
 <div class="graft-card-mark" aria-hidden="true">01</div>
-<h3>Define the domain</h3>
+<h3>Recognize the same thing</h3>
 <p>
-      Describe materials, sources, claims, evidence, or other project-specific
-      records as LinkML classes.
+      Use declared identifiers and workflow-specific keys to match new results
+      to existing records.
 </p>
 </div>
 <div class="graft-card">
 <div class="graft-card-mark" aria-hidden="true">02</div>
-<h3>Generate the manifest</h3>
+<h3>Keep claims traceable</h3>
 <p>
-      Resolve the schema once with <code>kg_compile_schema()</code>. Commit the
-      generated <code>.graft.json</code> file with the project.
+      Preserve what a source said, where it said it, and whether the stored
+      evidence supports or challenges the claim.
 </p>
 </div>
 <div class="graft-card">
 <div class="graft-card-mark" aria-hidden="true">03</div>
-<h3>Use the store from R</h3>
+<h3>Control retrieval</h3>
 <p>
-      Write validated records to DuckDB, query lazy dbplyr tables, and inspect
-      claims, evidence, identifiers, and graph neighborhoods.
+      Give R code schema-aware query helpers and AI tools structured access
+      without arbitrary SQL or invented relationships.
 </p>
 </div>
 </div>
 
-## The basic workflow
+## What graft does
 
 <div class="graft-flow" aria-label="The four-stage graft workflow">
 <div class="graft-flow-step">
 <span class="graft-flow-number">01</span>
-<strong>Write a schema</strong>
-<span>Describe the domain with ordinary LinkML classes and slots.</span>
+<strong>Define the contract</strong>
+<span>Describe records, identifiers, validation, and relationships.</span>
 </div>
 <div class="graft-flow-step">
 <span class="graft-flow-number">02</span>
-<strong>Compile it</strong>
-<span>Create a resolved <code>.graft.json</code> manifest.</span>
+<strong>Write workflow results</strong>
+<span>Ingest related data frames as one producer batch.</span>
 </div>
 <div class="graft-flow-step">
 <span class="graft-flow-number">03</span>
-<strong>Initialize a store</strong>
-<span>Create the declared tables and graph views in DuckDB.</span>
+<strong>Reconcile and validate</strong>
+<span>Reuse identities, check references, and record lineage.</span>
 </div>
 <div class="graft-flow-step">
 <span class="graft-flow-number">04</span>
-<strong>Read and write records</strong>
-<span>Use dbplyr tables or graft's collected query functions.</span>
+<strong>Retrieve with context</strong>
+<span>Inspect records together with claims, evidence, and relationships.</span>
 </div>
 </div>
 
-## A small example
+graft uses an ordinary LinkML schema as the source contract and compiles it
+into a portable <code>.graft.json</code> manifest. At runtime, that manifest
+drives validation, identity, storage, and retrieval. The current backend is
+embedded DuckDB, so stores are local and remain available through familiar DBI
+and dbplyr workflows.
+
+## From a data frame to a durable record
 
 ```r
 library(graft)
@@ -97,26 +104,44 @@ schema <- kg_schema(manifest)
 store <- kg_connect_duckdb(schema, ":memory:")
 kg_init(store)
 
-kg_classes(schema)
-kg_slots(schema, "Claim")
+kg_ingest(
+  store,
+  kg_batch(
+    producer = "materials-pipeline",
+    source_run_id = "run-42",
+    idempotency_key = "lldpe-v1"
+  ),
+  list(Material = data.frame(
+    preferred_name = "Linear low-density polyethylene",
+    cas_number = "9002-88-4"
+  ))
+)
+
+material_id <- kg_lookup(store, "cas", "CAS: 9002-88-4")$record_id[[1]]
+kg_get(store, material_id)
 ```
 
-Python and `linkml-runtime` are needed to compile a schema. Loading a compiled
-manifest and using a store run entirely in R.
+Reuse the same producer and idempotency key, and graft recognizes the write as
+a replay rather than a new observation. The getting-started guide continues
+from this foundation by adding a source-backed claim and retrieving the exact
+evidence stored with it.
+
+Python and `linkml-runtime` are needed only to compile a schema. Loading a
+committed manifest and using a store run entirely in R.
 
 ## Query interfaces
 
 <div class="graft-audience-grid">
 <div class="graft-audience">
-<h3>R and dbplyr</h3>
+<h3>Analysts and applications</h3>
 <p>
       <code>kg_records()</code> returns a lazy dbplyr table.
       <code>kg_find()</code>, <code>kg_get()</code>, and the graph helpers
-      return collected results with explicit limits.
+      return collected results with explicit limits and schema context.
 </p>
 </div>
 <div class="graft-audience">
-<h3>ellmer tools</h3>
+<h3>AI tools</h3>
 <p>
       <code>kg_tools()</code> creates six read-only tools for one store. The
       tools accept structured arguments rather than SQL and report truncation

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -126,8 +126,8 @@ a replay rather than a new observation. The getting-started guide continues
 from this foundation by adding a source-backed claim and retrieving the exact
 evidence stored with it.
 
-Python and `linkml-runtime` are needed only to compile a schema. Loading a
-committed manifest and using a store run entirely in R.
+Python and `linkml-runtime` are needed only to compile a schema. After
+compilation, graft loads committed manifests and operates stores entirely in R.
 
 ## Query interfaces
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "Getting started with graft"
 description: >
-  Build a small materials store from a compiled LinkML schema, add a
-  source-backed claim, and query it from R.
+  Keep records consistent across workflow runs, add a source-backed claim,
+  and retrieve its evidence from R.
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Getting started with graft}
@@ -17,12 +17,13 @@ knitr::opts_chunk$set(
 )
 ```
 
-graft stores schema-defined knowledge in DuckDB. A store can contain domain
-records, claims about those records, sources, and evidence that links a claim
-to a location in a source.
+An R workflow can end with well-formed data frames and still leave important
+questions unresolved. Is this the same material seen in an earlier run? Which
+source supports a claim? Is a relationship stated by the source or inferred by
+the application? What can another analyst or an AI tool safely retrieve?
 
-The schema records decisions that are otherwise easy to spread across
-application code:
+graft records those decisions in one versioned contract and applies the
+contract whenever data are written or read. It covers:
 
 - which fields identify the same record across runs;
 - which fields are required and how they are validated;
@@ -30,9 +31,13 @@ application code:
 - how claims, sources, and evidence are related; and
 - which relationships are available as graph projections.
 
-graft expresses these decisions in [LinkML](https://linkml.io/) and compiles
-the schema into a JSON manifest. At runtime, the manifest defines the DuckDB
-tables and the behavior of graft's read and write functions.
+With the contract in place, repeated workflow runs can recognize the same
+record, claims remain separate from adjudicated truth, and retrieval can return
+the exact source location stored with an assertion.
+
+graft expresses the contract in [LinkML](https://linkml.io/) and compiles it
+into a portable JSON manifest. At runtime, the manifest governs identity,
+validation, storage, and retrieval.
 
 This guide uses the materials schema included with the package. It creates an
 in-memory store, writes a material and a source, adds a claim and its evidence,
@@ -40,23 +45,28 @@ and then queries the result.
 
 ## How the pieces fit together
 
-The main workflow is:
+From a package user's perspective, the main workflow is:
 
-> LinkML schema -> compiled `.graft.json` manifest -> DuckDB store -> R queries
+> domain contract -> validated workflow results -> connected records -> bounded R retrieval
 
 Each part has one job:
 
-1. **The LinkML schema describes your domain.** You define concrete classes
-   such as materials, sources, claims, and evidence by extending graft's core
-   record roles.
-2. **The compiled manifest is the runtime contract.** It contains the resolved
-   classes, fields, relational mapping, identity rules, validation rules, graph
-   projections, and schema fingerprints. Commit it with your project.
-3. **DuckDB stores the records.** The database remains table-native, portable,
-   and available to familiar DBI and dbplyr workflows.
-4. **graft applies the contract.** Read and write functions accept only
-   manifest-declared classes and fields. Functions that collect results require
-   explicit limits and report the active schema digest.
+1. **Describe the domain.** Use ordinary LinkML classes and slots for the
+   records your workflow produces. Add graft's optional roles when you need
+   explicit claims, sources, evidence, or graph behavior.
+2. **Compile the runtime contract.** The generated `.graft.json` manifest
+   resolves fields, identity rules, validation, relationships, and schema
+   fingerprints. Commit it with your project.
+3. **Ingest workflow results.** graft validates related data frames atomically,
+   reconciles declared identifiers, and records the producer and replay
+   boundary.
+4. **Retrieve records with context.** Read one class lazily with dbplyr or use
+   bounded functions to inspect records, claims, evidence, and graph
+   neighborhoods.
+
+The current backend is embedded DuckDB. That keeps stores local, portable, and
+available to familiar DBI and dbplyr workflows without making the backend the
+domain model.
 
 Python and `linkml-runtime` are used only for step 2. Loading an existing
 manifest and performing normal storage or retrieval both run entirely in R.


### PR DESCRIPTION
## Summary

- Reframe the homepage, README, and getting-started guide around consistent, connected, and traceable workflow results.
- Lead with stable identity, schema-checked ingestion, claims and evidence, and controlled retrieval while presenting DuckDB as the backend.
- Replace schema-inspection-only examples with runnable ingest-and-retrieve workflows and align the package metadata.

## Verification

- `air format .`
- `Rscript -e 'pkgdown::check_pkgdown()'`
- `Rscript -e 'pkgdown::build_site()'`
- `Rscript -e 'devtools::check()'` — 0 errors, 0 warnings, and one environment-only time-verification note
- Executed both new ingest-and-retrieve examples successfully
