### PR TITLE
feat: add the continuous intelligence briefing room

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,10 +23,12 @@ Imports:
     reticulate,
     rlang
 Suggests:
+    bslib (>= 0.9.0),
     ellmer (>= 0.3.0),
     knitr,
     rmarkdown,
     S7,
+    shiny (>= 1.11.1),
     tempest (>= 0.1.0),
     testthat (>= 3.0.0),
     withr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # graft 0.0.0.9000
 
-* A provider-free continuous-intelligence example and staged operator walkthrough demonstrate scheduled Tempest briefings, host-bound promotion and approval, evidence-checked decisions, and governed Graft ingestion.
+* A provider-free continuous-intelligence example, staged operator walkthrough, and interactive Shiny Briefing Room demonstrate scheduled Tempest briefings, host-bound promotion and approval, evidence-checked decisions, and governed Graft ingestion.
 * Store format 2 adds complete system-time revision history and rejects stores created by earlier development versions instead of silently upgrading or operating in a legacy mode.
 * `kg_apply_migration()` atomically applies an unmodified reviewed migration plan after revalidating its digest and store preconditions; the first migration version accepts only compatible and supported additive changes.
 * `kg_batch()` creates stable producer batches, and `kg_ingest()` atomically

--- a/README.md
+++ b/README.md
@@ -94,7 +94,14 @@ example <- system.file(
 file.show(file.path(example, "README.md"))
 ```
 
-To take the operator's seat:
+Open the interactive Briefing Room to advance the three mornings, inspect
+accepted evidence, and act at each approval boundary:
+
+```r
+shiny::runApp(file.path(example, "app"))
+```
+
+Or take the operator's seat in the console:
 
 ```r
 source(file.path(example, "walkthrough.R"))

--- a/inst/examples/continuous-intelligence/R/blue-sky.R
+++ b/inst/examples/continuous-intelligence/R/blue-sky.R
@@ -472,14 +472,16 @@ blue_sky_result_builder <- function(
       torque_unit,
       "under Project Ember's representative thermal conditions."
     ),
-    uncertainty = paste(
-      "Independent evidence stops at",
+    uncertainty = paste0(
+      "Independent evidence stops at ",
       validated_duration,
+      " ",
       validated_duration_unit,
-      "; thermal behavior during the final",
+      "; thermal behavior during the final ",
       unvalidated_duration,
+      " ",
       duty_unit,
-      "remains unresolved."
+      " remains unresolved."
     ),
     owner = "Project Ember test lead",
     next_step = paste(

--- a/inst/examples/continuous-intelligence/R/scenario.R
+++ b/inst/examples/continuous-intelligence/R/scenario.R
@@ -1,0 +1,522 @@
+ci_scenario_new <- function(example_dir, store_path = NULL) {
+  if (!dir.exists(example_dir)) {
+    stop("`example_dir` must identify the continuous-intelligence example.")
+  }
+  example_dir <- normalizePath(example_dir, mustWork = TRUE)
+  owns_store_path <- is.null(store_path)
+  if (owns_store_path) {
+    store_path <- tempfile("blue-sky-scenario-", fileext = ".duckdb")
+  }
+
+  profile <- ci_read_json(
+    file.path(example_dir, "profiles", "blue-sky.json")
+  )
+  schema <- graft::kg_schema(
+    file.path(example_dir, "schema", "blue-sky.graft.json")
+  )
+  store <- graft::kg_connect_duckdb(schema, store_path)
+  initialized <- FALSE
+  on.exit(
+    {
+      if (!initialized) {
+        graft::kg_disconnect(store)
+        if (owns_store_path) {
+          unlink(store_path)
+        }
+      }
+    },
+    add = TRUE
+  )
+  graft::kg_init(store)
+
+  baseline <- jsonlite::fromJSON(
+    file.path(example_dir, "corpus", "baseline.json")
+  )
+  invisible(graft::kg_ingest(
+    store,
+    graft::kg_batch(
+      "blue-sky-scenario",
+      idempotency_key = "blue-sky-baseline"
+    ),
+    baseline
+  ))
+
+  scenario <- new.env(parent = emptyenv())
+  scenario$example_dir <- example_dir
+  scenario$profile <- profile
+  scenario$store <- store
+  scenario$store_path <- store_path
+  scenario$owns_store_path <- owns_store_path
+  scenario$status <- "active"
+  scenario$stage <- "welcome"
+  scenario$stopped_at <- NULL
+  scenario$closed <- FALSE
+  scenario$promotion_store <- NULL
+  scenario$state <- list(
+    monitor_runs = list(),
+    review_runs = list(),
+    decision_run = NULL,
+    promotion_record = NULL,
+    ingests = list()
+  )
+  class(scenario) <- "ci_scenario"
+  initialized <- TRUE
+  scenario
+}
+
+ci_scenario_validate <- function(scenario, require_active = FALSE) {
+  if (!inherits(scenario, "ci_scenario")) {
+    stop("`scenario` must be a continuous-intelligence scenario.")
+  }
+  if (isTRUE(scenario$closed)) {
+    stop("The continuous-intelligence scenario is closed.")
+  }
+  if (require_active && !identical(scenario$status, "active")) {
+    stop("The continuous-intelligence scenario is not active.")
+  }
+  invisible(scenario)
+}
+
+ci_scenario_close <- function(scenario) {
+  if (!inherits(scenario, "ci_scenario") || isTRUE(scenario$closed)) {
+    return(invisible(NULL))
+  }
+  disconnect_error <- NULL
+  tryCatch(
+    graft::kg_disconnect(scenario$store),
+    error = function(error) {
+      disconnect_error <<- error
+    }
+  )
+  if (isTRUE(scenario$owns_store_path)) {
+    unlink(scenario$store_path)
+  }
+  scenario$closed <- TRUE
+  if (!is.null(disconnect_error)) {
+    stop(disconnect_error)
+  }
+  invisible(NULL)
+}
+
+ci_scenario_run_signal_day <- function(scenario, date, corpus_file) {
+  monitor_id <- paste0("blue-sky-monitor-", date)
+  review_id <- paste0("blue-sky-review-", date)
+  daily_bundle <- ci_read_json(
+    file.path(scenario$example_dir, "corpus", corpus_file)
+  )
+  monitor <- ci_run_monitor(
+    scenario$profile,
+    daily_bundle,
+    scenario$store,
+    monitor_id
+  )
+  review <- ci_run_knowledge_review(
+    monitor,
+    monitor_id,
+    review_id,
+    scenario$store
+  )
+  list(
+    monitor_id = monitor_id,
+    review_id = review_id,
+    monitor = monitor,
+    review = review
+  )
+}
+
+ci_scenario_artifact_content <- function(run, artifact_id) {
+  tempest::tempest_run_artifact(run, artifact_id)@content
+}
+
+ci_scenario_stage <- function(scenario) {
+  ci_scenario_validate(scenario)
+  state <- scenario$state
+  stage <- scenario$stage
+
+  if (identical(stage, "welcome")) {
+    return(list(
+      id = stage,
+      phase = "Before the first morning",
+      title = "The Blue-Sky Briefing Room",
+      detail = paste(
+        "You are the technology executive for a themed-experience",
+        "organization. Over three simulated mornings, you will review",
+        "briefings, govern candidate knowledge, and make one bounded",
+        "decision without authorizing deployment."
+      ),
+      format = "text",
+      action = "continue",
+      action_label = "Run morning one"
+    ))
+  }
+  if (identical(stage, "supplier-briefing")) {
+    return(list(
+      id = stage,
+      phase = "Morning one · July 14",
+      title = "Supplier signal",
+      detail = ci_scenario_artifact_content(
+        state$monitor_runs[[1L]],
+        "daily-briefing-md"
+      ),
+      format = "markdown",
+      action = "continue",
+      action_label = "Review candidate knowledge"
+    ))
+  }
+  if (identical(stage, "supplier-knowledge")) {
+    content <- ci_scenario_artifact_content(
+      state$review_runs[[1L]],
+      "knowledge-change-set-json"
+    )
+    return(list(
+      id = stage,
+      phase = "Morning one · Review boundary",
+      title = "Supplier records await approval",
+      detail = paste(
+        ci_proposal_count(content$knowledge_changes),
+        paste(
+          "candidate records remain outside Graft.",
+          "Approval accepts the observations and their evidence lineage;",
+          "it does not authorize a prototype or deployment."
+        )
+      ),
+      format = "text",
+      action = "approve",
+      action_label = "Approve into Graft"
+    ))
+  }
+  if (identical(stage, "independent-briefing")) {
+    return(list(
+      id = stage,
+      phase = "Morning two · July 15",
+      title = "Independent evidence",
+      detail = ci_scenario_artifact_content(
+        state$monitor_runs[[2L]],
+        "daily-briefing-md"
+      ),
+      format = "markdown",
+      action = "continue",
+      action_label = "Review candidate knowledge"
+    ))
+  }
+  if (identical(stage, "independent-knowledge")) {
+    content <- ci_scenario_artifact_content(
+      state$review_runs[[2L]],
+      "knowledge-change-set-json"
+    )
+    return(list(
+      id = stage,
+      phase = "Morning two · Review boundary",
+      title = "Independent records await approval",
+      detail = paste(
+        ci_proposal_count(content$knowledge_changes),
+        paste(
+          "candidate records remain outside Graft.",
+          "Approval accepts the source-faithful observations,",
+          "but does not authorize the referred workflow."
+        )
+      ),
+      format = "text",
+      action = "approve",
+      action_label = "Approve into Graft"
+    ))
+  }
+  if (identical(stage, "workflow-promotion")) {
+    content <- ci_scenario_artifact_content(
+      state$monitor_runs[[2L]],
+      "monitor-result-json"
+    )
+    referral <- content$referrals[[1L]]
+    return(list(
+      id = stage,
+      phase = "Morning two · Routing boundary",
+      title = "A decision workflow is ready",
+      detail = paste(
+        referral$reason,
+        paste0("Objective: ", referral$objective),
+        "Promotion opens the workflow; it does not approve its result.",
+        sep = "\n\n"
+      ),
+      format = "text",
+      action = "promote",
+      action_label = "Promote decision workflow"
+    ))
+  }
+  if (identical(stage, "decision-approval")) {
+    content <- ci_scenario_artifact_content(
+      state$decision_run,
+      "workflow-referral-result-json"
+    )
+    return(list(
+      id = stage,
+      phase = "Morning two · Decision boundary",
+      title = "Bounded prototype test",
+      detail = paste(
+        content$recommendation,
+        paste(
+          "Approval commits this decision and supersedes the prior hold.",
+          "It does not authorize deployment."
+        ),
+        sep = "\n\n"
+      ),
+      format = "text",
+      action = "approve",
+      action_label = "Approve bounded test"
+    ))
+  }
+  if (identical(stage, "no-change-briefing")) {
+    return(list(
+      id = stage,
+      phase = "Morning three · July 16",
+      title = "No material change",
+      detail = ci_scenario_artifact_content(
+        state$monitor_runs[[3L]],
+        "daily-briefing-md"
+      ),
+      format = "markdown",
+      action = "continue",
+      action_label = "Complete the walkthrough"
+    ))
+  }
+  if (identical(stage, "completed")) {
+    return(list(
+      id = stage,
+      phase = "Scenario complete",
+      title = "The decision memory is ready for tomorrow",
+      detail = paste(
+        "The prior hold is superseded, the bounded test is the active",
+        "decision, and the final briefing retrieved that accepted history",
+        "without inventing a new signal."
+      ),
+      format = "text",
+      action = NULL,
+      action_label = NULL
+    ))
+  }
+  if (identical(stage, "stopped")) {
+    return(list(
+      id = stage,
+      phase = "Scenario stopped",
+      title = "No pending action was performed",
+      detail = paste(
+        "The operator stopped at",
+        scenario$stopped_at,
+        "and the corresponding write or promotion did not occur."
+      ),
+      format = "text",
+      action = NULL,
+      action_label = NULL
+    ))
+  }
+  stop("The continuous-intelligence scenario has an unknown stage.")
+}
+
+ci_scenario_advance <- function(scenario) {
+  ci_scenario_validate(scenario, require_active = TRUE)
+  state <- scenario$state
+  stage <- scenario$stage
+
+  if (identical(stage, "welcome")) {
+    if (length(state$monitor_runs) < 1L) {
+      day_one <- ci_scenario_run_signal_day(
+        scenario,
+        "2026-07-14",
+        "2026-07-14-supplier.json"
+      )
+      state$monitor_runs[[1L]] <- day_one$monitor
+      state$review_runs[[1L]] <- day_one$review
+    }
+    scenario$stage <- "supplier-briefing"
+  } else if (identical(stage, "supplier-briefing")) {
+    scenario$stage <- "supplier-knowledge"
+  } else if (identical(stage, "supplier-knowledge")) {
+    if (length(state$ingests) < 1L) {
+      committed <- ci_approve_and_commit(
+        state$review_runs[[1L]],
+        "knowledge-change-set-json",
+        scenario$store,
+        "blue-sky-review-2026-07-14",
+        "Approved source-faithful supplier observations."
+      )
+      state$review_runs[[1L]] <- committed$run
+      state$ingests[[1L]] <- committed$ingest
+      scenario$state <- state
+    }
+    if (length(state$monitor_runs) < 2L) {
+      day_two <- ci_scenario_run_signal_day(
+        scenario,
+        "2026-07-15",
+        "2026-07-15-independent.json"
+      )
+      state$monitor_runs[[2L]] <- day_two$monitor
+      state$review_runs[[2L]] <- day_two$review
+    }
+    scenario$stage <- "independent-briefing"
+  } else if (identical(stage, "independent-briefing")) {
+    scenario$stage <- "independent-knowledge"
+  } else if (identical(stage, "independent-knowledge")) {
+    if (length(state$ingests) < 2L) {
+      committed <- ci_approve_and_commit(
+        state$review_runs[[2L]],
+        "knowledge-change-set-json",
+        scenario$store,
+        "blue-sky-review-2026-07-15",
+        "Approved source-faithful independent observations."
+      )
+      state$review_runs[[2L]] <- committed$run
+      state$ingests[[2L]] <- committed$ingest
+      scenario$state <- state
+    }
+    scenario$stage <- "workflow-promotion"
+  } else if (identical(stage, "workflow-promotion")) {
+    monitor_content <- ci_scenario_artifact_content(
+      state$monitor_runs[[2L]],
+      "monitor-result-json"
+    )
+    referral <- monitor_content$referrals[[1L]]
+    if (is.null(scenario$promotion_store)) {
+      scenario$promotion_store <- ci_promotion_store()
+    }
+    promotion_id <- "blue-sky:promotion:prototype-gate:2026-07-15"
+    if (is.null(state$promotion_record)) {
+      ci_record_promotion(
+        scenario$promotion_store,
+        promotion_id,
+        referral,
+        reviewer = "technology portfolio owner",
+        decided_at = "2026-07-15T13:30:00Z",
+        note = "Open the prototype-gate decision workflow."
+      )
+      state$promotion_record <-
+        scenario$promotion_store$records[[promotion_id]]
+      scenario$state <- state
+    }
+    if (is.null(state$decision_run)) {
+      state$decision_run <- ci_run_referral(
+        referral,
+        scenario$profile,
+        scenario$store,
+        blue_sky_result_builder,
+        "blue-sky-decision-2026-07-15",
+        promotion_store = scenario$promotion_store,
+        promotion_id = promotion_id
+      )
+    }
+    scenario$stage <- "decision-approval"
+  } else if (identical(stage, "decision-approval")) {
+    if (length(state$ingests) < 3L) {
+      committed <- ci_approve_and_commit(
+        state$decision_run,
+        "workflow-referral-result-json",
+        scenario$store,
+        "blue-sky-decision-2026-07-15",
+        "Approved a bounded bench test; deployment remains unauthorized.",
+        record_mapper = blue_sky_decision_record_mapper
+      )
+      state$decision_run <- committed$run
+      state$ingests[[3L]] <- committed$ingest
+      scenario$state <- state
+    }
+    if (length(state$monitor_runs) < 3L) {
+      state$monitor_runs[[3L]] <- ci_run_monitor(
+        scenario$profile,
+        ci_read_json(file.path(
+          scenario$example_dir,
+          "corpus",
+          "2026-07-16-no-change.json"
+        )),
+        scenario$store,
+        "blue-sky-monitor-2026-07-16"
+      )
+    }
+    scenario$stage <- "no-change-briefing"
+  } else if (identical(stage, "no-change-briefing")) {
+    scenario$stage <- "completed"
+    scenario$status <- "completed"
+  } else {
+    stop("The current scenario stage cannot advance.")
+  }
+
+  scenario$state <- state
+  invisible(ci_scenario_stage(scenario))
+}
+
+ci_scenario_stop <- function(scenario) {
+  ci_scenario_validate(scenario, require_active = TRUE)
+  scenario$stopped_at <- scenario$stage
+  scenario$stage <- "stopped"
+  scenario$status <- "stopped"
+  invisible(ci_scenario_stage(scenario))
+}
+
+ci_scenario_counts <- function(scenario) {
+  ci_scenario_validate(scenario)
+  list(
+    assessment_count = nrow(dplyr::collect(
+      graft::kg_records(scenario$store, "Assessment")
+    )),
+    decision_count = nrow(dplyr::collect(
+      graft::kg_records(scenario$store, "ReviewDecision")
+    ))
+  )
+}
+
+ci_scenario_result <- function(scenario) {
+  ci_scenario_validate(scenario)
+  counts <- ci_scenario_counts(scenario)
+  c(
+    list(
+      status = scenario$status,
+      stopped_at = scenario$stopped_at
+    ),
+    scenario$state,
+    counts
+  )
+}
+
+ci_scenario_timeline <- function(scenario) {
+  ci_scenario_validate(scenario)
+  stages <- c(
+    "welcome",
+    "supplier-briefing",
+    "supplier-knowledge",
+    "independent-briefing",
+    "independent-knowledge",
+    "workflow-promotion",
+    "decision-approval",
+    "no-change-briefing",
+    "completed"
+  )
+  labels <- c(
+    "Baseline accepted",
+    "Supplier briefing",
+    "Supplier knowledge review",
+    "Independent briefing",
+    "Independent knowledge review",
+    "Decision workflow promotion",
+    "Bounded decision review",
+    "No-change briefing",
+    "Decision memory ready"
+  )
+  current_index <- if (identical(scenario$stage, "stopped")) {
+    match(scenario$stopped_at, stages)
+  } else {
+    match(scenario$stage, stages)
+  }
+  status <- rep("upcoming", length(stages))
+  status[seq_len(max(1L, current_index - 1L))] <- "complete"
+  status[[current_index]] <- if (identical(scenario$stage, "stopped")) {
+    "stopped"
+  } else {
+    "current"
+  }
+  if (identical(scenario$stage, "completed")) {
+    status[] <- "complete"
+  }
+  data.frame(
+    stage = stages,
+    label = labels,
+    status = status,
+    stringsAsFactors = FALSE
+  )
+}

--- a/inst/examples/continuous-intelligence/R/scenario.R
+++ b/inst/examples/continuous-intelligence/R/scenario.R
@@ -164,6 +164,20 @@ ci_scenario_stage <- function(scenario) {
     ))
   }
   if (identical(stage, "supplier-knowledge")) {
+    if (length(state$ingests) >= 1L) {
+      return(list(
+        id = stage,
+        phase = "Morning two · Retry",
+        title = "Supplier records are already accepted",
+        detail = paste(
+          "The Graft approval succeeded, but morning two did not finish.",
+          "Retry resumes independent monitoring without repeating the write."
+        ),
+        format = "text",
+        action = "retry",
+        action_label = "Retry morning two"
+      ))
+    }
     content <- ci_scenario_artifact_content(
       state$review_runs[[1L]],
       "knowledge-change-set-json"
@@ -222,6 +236,21 @@ ci_scenario_stage <- function(scenario) {
     ))
   }
   if (identical(stage, "workflow-promotion")) {
+    if (!is.null(state$promotion_record)) {
+      return(list(
+        id = stage,
+        phase = "Morning two · Retry",
+        title = "The decision workflow is already promoted",
+        detail = paste(
+          "The promotion record is committed, but the referred workflow",
+          "did not finish. Retry resumes it without recording another",
+          "promotion."
+        ),
+        format = "text",
+        action = "retry",
+        action_label = "Retry decision workflow"
+      ))
+    }
     content <- ci_scenario_artifact_content(
       state$monitor_runs[[2L]],
       "monitor-result-json"
@@ -247,6 +276,24 @@ ci_scenario_stage <- function(scenario) {
       state$decision_run,
       "workflow-referral-result-json"
     )
+    if (length(state$ingests) >= 3L) {
+      return(list(
+        id = stage,
+        phase = "Morning three · Retry",
+        title = "The bounded test decision is already accepted",
+        detail = paste(
+          content$recommendation,
+          paste(
+            "The Graft approval succeeded, but morning three did not finish.",
+            "Retry resumes the scheduled scan without repeating the write."
+          ),
+          sep = "\n\n"
+        ),
+        format = "text",
+        action = "retry",
+        action_label = "Retry morning three"
+      ))
+    }
     return(list(
       id = stage,
       phase = "Morning two · Decision boundary",

--- a/inst/examples/continuous-intelligence/README.md
+++ b/inst/examples/continuous-intelligence/README.md
@@ -52,6 +52,45 @@ The example promotion store is process-local and represents a host-owned
 approval boundary. A production host must persist those records and authorize
 who can create them.
 
+## Open the Briefing Room
+
+The Shiny Briefing Room turns the same deterministic scenario into an
+executive-facing application. Each browser session owns a temporary Graft
+store. Use the primary action to run the next morning or cross the displayed
+review boundary, and use **Stop here** to verify that the pending write or
+promotion does not occur.
+
+From a development checkout:
+
+```r
+devtools::load_all("../tempest")
+devtools::load_all(".")
+shiny::runApp("inst/examples/continuous-intelligence/app")
+```
+
+From an installed package:
+
+```r
+example <- system.file(
+  "examples",
+  "continuous-intelligence",
+  package = "graft",
+  mustWork = TRUE
+)
+shiny::runApp(file.path(example, "app"))
+```
+
+The four views separate the executive brief, promoted decision packet,
+accepted knowledge and evidence, and the Tempest/Graft audit trail. The
+comparison in the Decision room is deliberately explicit: a briefing alone
+can summarize a signal, while governed memory can establish which accepted
+position changed, why it changed, and what evidence and approval support it.
+
+The **Run morning** controls simulate a scheduler for the frozen corpus. The
+app does not claim to provide production scheduling, authentication, durable
+promotion storage, or multi-user concurrency; those remain host
+responsibilities.
+
 ## Take the operator's seat
 
 The staged walkthrough presents the same scenario one boundary at a time.
@@ -97,6 +136,9 @@ rehearsal <- run_continuous_intelligence_walkthrough(
 - `R/host.R` is the domain-neutral reference host.
 - `R/blue-sky.R` maps the promoted referral into the application-specific
   decision result and approved Graft records.
+- `R/scenario.R` is the resumable example-local state machine shared by the
+  console, automatic demo, and Shiny app.
+- `app/` is the interactive Briefing Room reference host.
 - `walkthrough.R` is the staged operator experience.
 
 ## Reconfigure the loop

--- a/inst/examples/continuous-intelligence/app/R/data.R
+++ b/inst/examples/continuous-intelligence/app/R/data.R
@@ -178,8 +178,14 @@ ci_app_pending_count <- function(scenario) {
     },
     logical(1)
   ))
+  retry_needed <-
+    (identical(scenario$stage, "supplier-knowledge") &&
+      length(scenario$state$ingests) >= 1L) ||
+    identical(scenario$stage, "workflow-promotion") ||
+    (identical(scenario$stage, "decision-approval") &&
+      length(scenario$state$ingests) >= 3L)
   as.integer(awaiting_approval) +
-    as.integer(identical(scenario$stage, "workflow-promotion"))
+    as.integer(retry_needed)
 }
 
 ci_app_active_position <- function(scenario) {

--- a/inst/examples/continuous-intelligence/app/R/data.R
+++ b/inst/examples/continuous-intelligence/app/R/data.R
@@ -1,0 +1,167 @@
+ci_app_latest_monitor <- function(scenario) {
+  runs <- scenario$state$monitor_runs
+  if (length(runs) == 0L) {
+    return(NULL)
+  }
+  runs[[length(runs)]]
+}
+
+ci_app_latest_briefing <- function(scenario) {
+  monitor <- ci_app_latest_monitor(scenario)
+  if (is.null(monitor)) {
+    return(NULL)
+  }
+  ci_scenario_artifact_content(monitor, "daily-briefing-md")
+}
+
+ci_app_latest_monitor_content <- function(scenario) {
+  monitor <- ci_app_latest_monitor(scenario)
+  if (is.null(monitor)) {
+    return(NULL)
+  }
+  ci_scenario_artifact_content(monitor, "monitor-result-json")
+}
+
+ci_app_decision_content <- function(scenario) {
+  if (is.null(scenario$state$decision_run)) {
+    return(NULL)
+  }
+  ci_scenario_artifact_content(
+    scenario$state$decision_run,
+    "workflow-referral-result-json"
+  )
+}
+
+ci_app_decision_records <- function(scenario) {
+  records <- dplyr::collect(
+    graft::kg_records(scenario$store, "ReviewDecision")
+  )
+  columns <- intersect(
+    c(
+      "status",
+      "disposition",
+      "statement_text",
+      "reviewer_role",
+      "asserted_at"
+    ),
+    names(records)
+  )
+  records <- records[, columns, drop = FALSE]
+  if ("asserted_at" %in% names(records)) {
+    records$asserted_at <- format(
+      records$asserted_at,
+      "%Y-%m-%d %H:%M UTC",
+      tz = "UTC"
+    )
+  }
+  names(records) <- c(
+    status = "Status",
+    disposition = "Position",
+    statement_text = "Decision",
+    reviewer_role = "Reviewer",
+    asserted_at = "Accepted at"
+  )[names(records)]
+  records
+}
+
+ci_app_decision_evidence <- function(scenario) {
+  decisions <- dplyr::collect(
+    graft::kg_records(scenario$store, "ReviewDecision")
+  )
+  active <- decisions[decisions$status == "active", , drop = FALSE]
+  if (nrow(active) == 0L) {
+    return(data.frame())
+  }
+  accepted <- graft::kg_get(
+    scenario$store,
+    active$id[[nrow(active)]],
+    include = "evidence"
+  )
+  evidence <- accepted$evidence
+  columns <- intersect(
+    c("support_type", "excerpt", "locator_type", "locator_value"),
+    names(evidence)
+  )
+  evidence <- evidence[, columns, drop = FALSE]
+  names(evidence) <- c(
+    support_type = "Support",
+    excerpt = "Evidence excerpt",
+    locator_type = "Locator",
+    locator_value = "Location"
+  )[names(evidence)]
+  evidence
+}
+
+ci_app_batch_history <- function(scenario) {
+  batches <- graft::kg_batches(scenario$store, limit = 20L)
+  columns <- intersect(
+    c(
+      "commit_order",
+      "producer",
+      "source_run_id",
+      "status",
+      "committed_at"
+    ),
+    names(batches)
+  )
+  batches <- batches[, columns, drop = FALSE]
+  if ("commit_order" %in% names(batches)) {
+    batches$commit_order <- as.integer(batches$commit_order)
+  }
+  if ("source_run_id" %in% names(batches)) {
+    batches$source_run_id[is.na(batches$source_run_id)] <- "baseline"
+  }
+  if ("committed_at" %in% names(batches)) {
+    batches$committed_at <- format(
+      batches$committed_at,
+      "%Y-%m-%d %H:%M UTC",
+      tz = "UTC"
+    )
+  }
+  names(batches) <- c(
+    commit_order = "Commit",
+    producer = "Producer",
+    source_run_id = "Source run",
+    status = "Status",
+    committed_at = "Committed at"
+  )[names(batches)]
+  batches
+}
+
+ci_app_workflow_runs <- function(scenario) {
+  state <- scenario$state
+  run_status <- function(run) {
+    if (is.null(run)) {
+      return(NA_character_)
+    }
+    tempest::tempest_run_status(run)
+  }
+  data.frame(
+    workflow = c(
+      paste("Monitor", seq_along(state$monitor_runs)),
+      paste("Knowledge review", seq_along(state$review_runs)),
+      if (!is.null(state$decision_run)) "Promoted decision" else character()
+    ),
+    status = c(
+      vapply(state$monitor_runs, run_status, character(1)),
+      vapply(state$review_runs, run_status, character(1)),
+      if (!is.null(state$decision_run)) {
+        run_status(state$decision_run)
+      } else {
+        character()
+      }
+    ),
+    stringsAsFactors = FALSE
+  )
+}
+
+ci_app_active_position <- function(scenario) {
+  decisions <- dplyr::collect(
+    graft::kg_records(scenario$store, "ReviewDecision")
+  )
+  active <- decisions[decisions$status == "active", , drop = FALSE]
+  if (nrow(active) == 0L || !"disposition" %in% names(active)) {
+    return("None")
+  }
+  tools::toTitleCase(active$disposition[[nrow(active)]])
+}

--- a/inst/examples/continuous-intelligence/app/R/data.R
+++ b/inst/examples/continuous-intelligence/app/R/data.R
@@ -138,8 +138,8 @@ ci_app_workflow_runs <- function(scenario) {
   }
   data.frame(
     workflow = c(
-      paste("Monitor", seq_along(state$monitor_runs)),
-      paste("Knowledge review", seq_along(state$review_runs)),
+      sprintf("Monitor %d", seq_along(state$monitor_runs)),
+      sprintf("Knowledge review %d", seq_along(state$review_runs)),
       if (!is.null(state$decision_run)) "Promoted decision" else character()
     ),
     status = c(
@@ -152,7 +152,34 @@ ci_app_workflow_runs <- function(scenario) {
       }
     ),
     stringsAsFactors = FALSE
+  ) |>
+    stats::setNames(c("Workflow", "Status"))
+}
+
+ci_app_pending_count <- function(scenario) {
+  if (!identical(scenario$status, "active")) {
+    return(0L)
+  }
+  runs <- c(
+    scenario$state$review_runs,
+    if (!is.null(scenario$state$decision_run)) {
+      list(scenario$state$decision_run)
+    } else {
+      list()
+    }
   )
+  awaiting_approval <- sum(vapply(
+    runs,
+    \(run) {
+      identical(
+        tempest::tempest_run_status(run),
+        "awaiting_approval"
+      )
+    },
+    logical(1)
+  ))
+  as.integer(awaiting_approval) +
+    as.integer(identical(scenario$stage, "workflow-promotion"))
 }
 
 ci_app_active_position <- function(scenario) {

--- a/inst/examples/continuous-intelligence/app/R/presentation.R
+++ b/inst/examples/continuous-intelligence/app/R/presentation.R
@@ -1,0 +1,324 @@
+ci_app_escape_markdown <- function(text) {
+  text <- gsub("&", "&amp;", text, fixed = TRUE)
+  text <- gsub("<", "&lt;", text, fixed = TRUE)
+  gsub(">", "&gt;", text, fixed = TRUE)
+}
+
+ci_app_theme <- function() {
+  bslib::bs_theme(
+    version = 5,
+    bg = "#f5f1e8",
+    fg = "#163033",
+    primary = "#006e73",
+    secondary = "#c88b35",
+    success = "#287a55",
+    danger = "#ad3d38",
+    base_font = bslib::font_collection(
+      "Avenir Next",
+      "Segoe UI",
+      "Helvetica Neue",
+      "sans-serif"
+    ),
+    heading_font = bslib::font_collection(
+      "Avenir Next",
+      "Segoe UI",
+      "Helvetica Neue",
+      "sans-serif"
+    )
+  )
+}
+
+ci_app_title <- function() {
+  shiny::div(
+    class = "app-title",
+    shiny::span(class = "app-kicker", "BLUE-SKY"),
+    shiny::span("Briefing Room")
+  )
+}
+
+ci_app_ui <- function() {
+  bslib::page_sidebar(
+    title = ci_app_title(),
+    window_title = "Blue-Sky Briefing Room",
+    lang = "en",
+    theme = ci_app_theme(),
+    sidebar = bslib::sidebar(
+      width = 330,
+      open = "desktop",
+      shiny::div(
+        class = "stage-panel",
+        shiny::div(
+          class = "stage-phase",
+          shiny::textOutput("stage_phase", inline = TRUE)
+        ),
+        shiny::h2(shiny::textOutput("stage_title", inline = TRUE)),
+        shiny::uiOutput("stage_summary"),
+        shiny::uiOutput("action_controls")
+      ),
+      shiny::hr(),
+      shiny::div(
+        class = "guardrail-note",
+        shiny::strong("Operating boundary"),
+        shiny::p(
+          paste(
+            "Briefings can propose. Only explicit review actions change",
+            "accepted Graft knowledge or open another Tempest workflow."
+          )
+        )
+      )
+    ),
+    bslib::layout_column_wrap(
+      width = "150px",
+      fill = FALSE,
+      class = "metric-grid",
+      bslib::value_box(
+        title = "Scheduled briefings",
+        value = shiny::textOutput("briefing_count", inline = TRUE),
+        theme = "primary",
+        class = "metric-box"
+      ),
+      bslib::value_box(
+        title = "Approved handoffs",
+        value = shiny::textOutput("handoff_count", inline = TRUE),
+        theme = "success",
+        class = "metric-box"
+      ),
+      bslib::value_box(
+        title = "Action queue",
+        value = shiny::textOutput("pending_count", inline = TRUE),
+        theme = "warning",
+        class = "metric-box"
+      ),
+      bslib::value_box(
+        title = "Active position",
+        value = shiny::textOutput("active_position", inline = TRUE),
+        theme = "secondary",
+        class = "metric-box"
+      )
+    ),
+    bslib::navset_underline(
+      id = "workspace",
+      bslib::nav_panel(
+        "Morning brief",
+        bslib::layout_columns(
+          col_widths = c(8, 4),
+          bslib::card(
+            full_screen = TRUE,
+            class = "briefing-card",
+            bslib::card_header(shiny::uiOutput("briefing_header")),
+            bslib::card_body(shiny::uiOutput("briefing_body"))
+          ),
+          bslib::card(
+            full_screen = TRUE,
+            bslib::card_header("Three-morning timeline"),
+            bslib::card_body(shiny::uiOutput("scenario_timeline"))
+          )
+        )
+      ),
+      bslib::nav_panel(
+        "Decision room",
+        bslib::layout_columns(
+          col_widths = c(7, 5),
+          bslib::card(
+            full_screen = TRUE,
+            bslib::card_header("Current decision packet"),
+            bslib::card_body(shiny::uiOutput("decision_packet"))
+          ),
+          bslib::card(
+            full_screen = TRUE,
+            bslib::card_header("Why governed memory matters"),
+            bslib::card_body(shiny::uiOutput("memory_comparison"))
+          )
+        )
+      ),
+      bslib::nav_panel(
+        "Knowledge ledger",
+        bslib::layout_columns(
+          col_widths = c(7, 5),
+          bslib::card(
+            full_screen = TRUE,
+            bslib::card_header("Review decisions in Graft"),
+            bslib::card_body(shiny::div(
+              class = "table-responsive",
+              shiny::tableOutput("decision_records")
+            ))
+          ),
+          bslib::card(
+            full_screen = TRUE,
+            bslib::card_header("Evidence bound to the active position"),
+            bslib::card_body(shiny::div(
+              class = "table-responsive",
+              shiny::tableOutput("decision_evidence")
+            ))
+          )
+        )
+      ),
+      bslib::nav_panel(
+        "Audit trail",
+        bslib::layout_columns(
+          col_widths = c(6, 6),
+          bslib::card(
+            full_screen = TRUE,
+            bslib::card_header("Committed Graft batches"),
+            bslib::card_body(shiny::div(
+              class = "table-responsive",
+              shiny::tableOutput("batch_history")
+            ))
+          ),
+          bslib::card(
+            full_screen = TRUE,
+            bslib::card_header("Tempest workflow runs"),
+            bslib::card_body(shiny::div(
+              class = "table-responsive",
+              shiny::tableOutput("workflow_runs")
+            ))
+          )
+        )
+      )
+    ),
+    shiny::includeCSS("www/briefing-room.css"),
+    shiny::tags$script(shiny::HTML(
+      paste(
+        paste0(
+          "Shiny.addCustomMessageHandler('ci-scroll-stage', ",
+          "function(message) {"
+        ),
+        "const sidebar = document.querySelector('aside.sidebar');",
+        "if (sidebar) sidebar.scrollTop = 0;",
+        "});"
+      )
+    ))
+  )
+}
+
+ci_app_timeline_tags <- function(scenario) {
+  timeline <- ci_scenario_timeline(scenario)
+  items <- lapply(seq_len(nrow(timeline)), function(index) {
+    row <- timeline[index, , drop = FALSE]
+    shiny::tags$li(
+      class = paste("timeline-item", paste0("is-", row$status)),
+      shiny::span(class = "timeline-marker", `aria-hidden` = "true"),
+      shiny::span(class = "timeline-label", row$label),
+      shiny::span(class = "timeline-status", row$status)
+    )
+  })
+  shiny::tags$ol(class = "scenario-timeline", items)
+}
+
+ci_app_stage_summary <- function(stage) {
+  if (identical(stage$format, "markdown")) {
+    return(shiny::p(
+      paste(
+        "The scheduled monitor has completed. Read the briefing, then",
+        "continue to the next governed boundary."
+      )
+    ))
+  }
+  shiny::p(stage$detail)
+}
+
+ci_app_stage_input_id <- function(action, stage_id) {
+  paste(action, gsub("-", "_", stage_id, fixed = TRUE), sep = "_")
+}
+
+ci_app_action_controls <- function(scenario, stage) {
+  if (!identical(scenario$status, "active")) {
+    return(shiny::actionButton(
+      "reset_scenario",
+      "Start over",
+      class = "btn-primary w-100"
+    ))
+  }
+  shiny::tagList(
+    shiny::actionButton(
+      ci_app_stage_input_id("advance", stage$id),
+      stage$action_label,
+      class = "btn-primary w-100"
+    ),
+    shiny::actionButton(
+      ci_app_stage_input_id("stop", stage$id),
+      "Stop here",
+      class = "btn-outline-secondary w-100 mt-2"
+    )
+  )
+}
+
+ci_app_decision_packet <- function(scenario) {
+  content <- ci_app_decision_content(scenario)
+  if (is.null(content)) {
+    return(shiny::div(
+      class = "empty-state",
+      shiny::h3("No promoted decision yet"),
+      shiny::p(
+        paste(
+          "A material briefing must first produce a referral, and an",
+          "operator must explicitly promote it."
+        )
+      )
+    ))
+  }
+  option_items <- lapply(content$options, function(option) {
+    shiny::tags$li(
+      shiny::strong(option$option),
+      shiny::span(option$consequence)
+    )
+  })
+  shiny::div(
+    class = "decision-packet",
+    shiny::div(class = "packet-label", "Prior accepted position"),
+    shiny::p(content$prior_position),
+    shiny::div(class = "packet-label", "Why now"),
+    shiny::p(content$why_now),
+    shiny::div(class = "packet-label", "Options considered"),
+    shiny::tags$ul(class = "decision-options", option_items),
+    shiny::div(class = "packet-label", "Recommendation"),
+    shiny::p(class = "recommendation", content$recommendation),
+    shiny::div(class = "packet-label", "Remaining uncertainty"),
+    shiny::p(content$uncertainty),
+    shiny::div(
+      class = "decision-owner",
+      shiny::strong("Owner: "),
+      content$owner,
+      shiny::br(),
+      shiny::strong("Next: "),
+      content$next_step
+    )
+  )
+}
+
+ci_app_memory_comparison <- function(scenario) {
+  content <- ci_app_decision_content(scenario)
+  governed <- if (is.null(content)) {
+    paste(
+      "Accepted history is available, but no promoted workflow has yet",
+      "bound the new evidence to a reviewable decision."
+    )
+  } else {
+    paste(
+      "The workflow can name the prior position, cite",
+      length(content$evidence_record_ids),
+      "accepted evidence records, and propose an explicit supersession."
+    )
+  }
+  shiny::div(
+    class = "comparison-stack",
+    shiny::div(
+      class = "comparison-card without-memory",
+      shiny::div(class = "comparison-label", "Briefing alone"),
+      shiny::h3("A useful summary, but no controlled continuity"),
+      shiny::p(
+        paste(
+          "A fresh report can repeat the 105 Nm result and thermal limit.",
+          "It cannot establish which prior decision was accepted, whether",
+          "the evidence passed review, or what the new decision supersedes."
+        )
+      )
+    ),
+    shiny::div(
+      class = "comparison-card with-memory",
+      shiny::div(class = "comparison-label", "Tempest + Graft"),
+      shiny::h3("A decision with provenance and a future"),
+      shiny::p(governed)
+    )
+  )
+}

--- a/inst/examples/continuous-intelligence/app/R/presentation.R
+++ b/inst/examples/continuous-intelligence/app/R/presentation.R
@@ -29,10 +29,23 @@ ci_app_theme <- function() {
 }
 
 ci_app_title <- function() {
-  shiny::div(
+  shiny::h1(
     class = "app-title",
     shiny::span(class = "app-kicker", "BLUE-SKY"),
     shiny::span("Briefing Room")
+  )
+}
+
+ci_app_card_title <- function(...) {
+  shiny::h2(class = "card-heading", ...)
+}
+
+ci_app_scope_markdown_headings <- function(text) {
+  gsub(
+    "(?m)^(#{1,4})([[:space:]])",
+    "##\\1\\2",
+    text,
+    perl = TRUE
   )
 }
 
@@ -110,7 +123,9 @@ ci_app_ui <- function() {
           ),
           bslib::card(
             full_screen = TRUE,
-            bslib::card_header("Three-morning timeline"),
+            bslib::card_header(
+              ci_app_card_title("Three-morning timeline")
+            ),
             bslib::card_body(shiny::uiOutput("scenario_timeline"))
           )
         )
@@ -121,12 +136,16 @@ ci_app_ui <- function() {
           col_widths = c(7, 5),
           bslib::card(
             full_screen = TRUE,
-            bslib::card_header("Current decision packet"),
+            bslib::card_header(
+              ci_app_card_title("Current decision packet")
+            ),
             bslib::card_body(shiny::uiOutput("decision_packet"))
           ),
           bslib::card(
             full_screen = TRUE,
-            bslib::card_header("Why governed memory matters"),
+            bslib::card_header(
+              ci_app_card_title("Why governed memory matters")
+            ),
             bslib::card_body(shiny::uiOutput("memory_comparison"))
           )
         )
@@ -137,7 +156,9 @@ ci_app_ui <- function() {
           col_widths = c(7, 5),
           bslib::card(
             full_screen = TRUE,
-            bslib::card_header("Review decisions in Graft"),
+            bslib::card_header(
+              ci_app_card_title("Review decisions in Graft")
+            ),
             bslib::card_body(shiny::div(
               class = "table-responsive",
               shiny::tableOutput("decision_records")
@@ -145,7 +166,11 @@ ci_app_ui <- function() {
           ),
           bslib::card(
             full_screen = TRUE,
-            bslib::card_header("Evidence bound to the active position"),
+            bslib::card_header(
+              ci_app_card_title(
+                "Evidence bound to the active position"
+              )
+            ),
             bslib::card_body(shiny::div(
               class = "table-responsive",
               shiny::tableOutput("decision_evidence")
@@ -159,7 +184,9 @@ ci_app_ui <- function() {
           col_widths = c(6, 6),
           bslib::card(
             full_screen = TRUE,
-            bslib::card_header("Committed Graft batches"),
+            bslib::card_header(
+              ci_app_card_title("Committed Graft batches")
+            ),
             bslib::card_body(shiny::div(
               class = "table-responsive",
               shiny::tableOutput("batch_history")
@@ -167,7 +194,9 @@ ci_app_ui <- function() {
           ),
           bslib::card(
             full_screen = TRUE,
-            bslib::card_header("Tempest workflow runs"),
+            bslib::card_header(
+              ci_app_card_title("Tempest workflow runs")
+            ),
             bslib::card_body(shiny::div(
               class = "table-responsive",
               shiny::tableOutput("workflow_runs")

--- a/inst/examples/continuous-intelligence/app/R/server.R
+++ b/inst/examples/continuous-intelligence/app/R/server.R
@@ -30,17 +30,9 @@ ci_app_server <- function(example_dir, scenario_factory = ci_scenario_new) {
     output$handoff_count <- shiny::renderText(
       length(current()$state$ingests)
     )
-    output$pending_count <- shiny::renderText({
-      as.integer(
-        current()$stage %in%
-          c(
-            "supplier-knowledge",
-            "independent-knowledge",
-            "workflow-promotion",
-            "decision-approval"
-          )
-      )
-    })
+    output$pending_count <- shiny::renderText(
+      ci_app_pending_count(current())
+    )
     output$active_position <- shiny::renderText(
       ci_app_active_position(current())
     )
@@ -48,13 +40,13 @@ ci_app_server <- function(example_dir, scenario_factory = ci_scenario_new) {
     output$briefing_header <- shiny::renderUI({
       content <- ci_app_latest_monitor_content(current())
       if (is.null(content)) {
-        return(shiny::tagList(
+        return(ci_app_card_title(
           shiny::span("Executive morning brief"),
           shiny::span(class = "status-badge is-waiting", "not run")
         ))
       }
-      shiny::tagList(
-        shiny::span(content$title),
+      ci_app_card_title(
+        shiny::span("Executive morning brief"),
         shiny::span(
           class = paste("status-badge", paste0("is-", content$status)),
           gsub("_", " ", content$status, fixed = TRUE)
@@ -78,7 +70,9 @@ ci_app_server <- function(example_dir, scenario_factory = ci_scenario_new) {
       }
       shiny::div(
         class = "briefing-markdown",
-        shiny::markdown(ci_app_escape_markdown(briefing))
+        shiny::markdown(ci_app_escape_markdown(
+          ci_app_scope_markdown_headings(briefing)
+        ))
       )
     })
     output$scenario_timeline <- shiny::renderUI(
@@ -208,6 +202,11 @@ ci_app_server <- function(example_dir, scenario_factory = ci_scenario_new) {
           previous <- shiny::isolate(scenario())
           scenario(replacement)
           revision(revision() + 1L)
+          bslib::nav_select(
+            "workspace",
+            "Morning brief",
+            session = session
+          )
           session$sendCustomMessage("ci-scroll-stage", list())
           ci_scenario_close(previous)
         }

--- a/inst/examples/continuous-intelligence/app/R/server.R
+++ b/inst/examples/continuous-intelligence/app/R/server.R
@@ -1,0 +1,219 @@
+ci_app_server <- function(example_dir, scenario_factory = ci_scenario_new) {
+  force(example_dir)
+  force(scenario_factory)
+  function(input, output, session) {
+    scenario <- shiny::reactiveVal(scenario_factory(example_dir))
+    revision <- shiny::reactiveVal(0L)
+
+    current <- shiny::reactive({
+      revision()
+      scenario()
+    })
+    current_stage <- shiny::reactive(ci_scenario_stage(current()))
+
+    session$onSessionEnded(function() {
+      ci_scenario_close(shiny::isolate(scenario()))
+    })
+
+    output$stage_phase <- shiny::renderText(current_stage()$phase)
+    output$stage_title <- shiny::renderText(current_stage()$title)
+    output$stage_summary <- shiny::renderUI(
+      ci_app_stage_summary(current_stage())
+    )
+    output$action_controls <- shiny::renderUI(
+      ci_app_action_controls(current(), current_stage())
+    )
+
+    output$briefing_count <- shiny::renderText(
+      paste0(length(current()$state$monitor_runs), " / 3")
+    )
+    output$handoff_count <- shiny::renderText(
+      length(current()$state$ingests)
+    )
+    output$pending_count <- shiny::renderText({
+      as.integer(
+        current()$stage %in%
+          c(
+            "supplier-knowledge",
+            "independent-knowledge",
+            "workflow-promotion",
+            "decision-approval"
+          )
+      )
+    })
+    output$active_position <- shiny::renderText(
+      ci_app_active_position(current())
+    )
+
+    output$briefing_header <- shiny::renderUI({
+      content <- ci_app_latest_monitor_content(current())
+      if (is.null(content)) {
+        return(shiny::tagList(
+          shiny::span("Executive morning brief"),
+          shiny::span(class = "status-badge is-waiting", "not run")
+        ))
+      }
+      shiny::tagList(
+        shiny::span(content$title),
+        shiny::span(
+          class = paste("status-badge", paste0("is-", content$status)),
+          gsub("_", " ", content$status, fixed = TRUE)
+        )
+      )
+    })
+    output$briefing_body <- shiny::renderUI({
+      briefing <- ci_app_latest_briefing(current())
+      if (is.null(briefing)) {
+        return(shiny::div(
+          class = "empty-state briefing-empty",
+          shiny::div(class = "sunrise-mark", `aria-hidden` = "true"),
+          shiny::h3("The room is quiet before the first scan"),
+          shiny::p(
+            paste(
+              "Run morning one to reconcile the frozen signal bundle",
+              "against accepted Graft context."
+            )
+          )
+        ))
+      }
+      shiny::div(
+        class = "briefing-markdown",
+        shiny::markdown(ci_app_escape_markdown(briefing))
+      )
+    })
+    output$scenario_timeline <- shiny::renderUI(
+      ci_app_timeline_tags(current())
+    )
+    output$decision_packet <- shiny::renderUI(
+      ci_app_decision_packet(current())
+    )
+    output$memory_comparison <- shiny::renderUI(
+      ci_app_memory_comparison(current())
+    )
+    output$decision_records <- shiny::renderTable(
+      ci_app_decision_records(current()),
+      striped = TRUE,
+      hover = TRUE,
+      spacing = "s"
+    )
+    output$decision_evidence <- shiny::renderTable(
+      ci_app_decision_evidence(current()),
+      striped = TRUE,
+      hover = TRUE,
+      spacing = "s"
+    )
+    output$batch_history <- shiny::renderTable(
+      ci_app_batch_history(current()),
+      striped = TRUE,
+      hover = TRUE,
+      spacing = "s"
+    )
+    output$workflow_runs <- shiny::renderTable(
+      ci_app_workflow_runs(current()),
+      striped = TRUE,
+      hover = TRUE,
+      spacing = "s"
+    )
+
+    active_stages <- c(
+      "welcome",
+      "supplier-briefing",
+      "supplier-knowledge",
+      "independent-briefing",
+      "independent-knowledge",
+      "workflow-promotion",
+      "decision-approval",
+      "no-change-briefing"
+    )
+    advance_observers <- lapply(active_stages, function(expected_stage) {
+      shiny::observeEvent(
+        input[[ci_app_stage_input_id("advance", expected_stage)]],
+        {
+          if (!identical(current()$stage, expected_stage)) {
+            return()
+          }
+          stage <- current_stage()
+          succeeded <- tryCatch(
+            {
+              shiny::withProgress(
+                message = stage$action_label,
+                value = 0.5,
+                ci_scenario_advance(shiny::isolate(scenario()))
+              )
+              TRUE
+            },
+            error = function(error) {
+              shiny::showNotification(
+                conditionMessage(error),
+                type = "error",
+                duration = NULL
+              )
+              FALSE
+            }
+          )
+          revision(revision() + 1L)
+          session$sendCustomMessage("ci-scroll-stage", list())
+          if (succeeded) {
+            shiny::showNotification(
+              "The scenario advanced through its governed boundary.",
+              type = "message",
+              duration = 3
+            )
+          }
+        },
+        ignoreInit = TRUE
+      )
+    })
+    stop_observers <- lapply(active_stages, function(expected_stage) {
+      shiny::observeEvent(
+        input[[ci_app_stage_input_id("stop", expected_stage)]],
+        {
+          if (!identical(current()$stage, expected_stage)) {
+            return()
+          }
+          ci_scenario_stop(shiny::isolate(scenario()))
+          revision(revision() + 1L)
+          session$sendCustomMessage("ci-scroll-stage", list())
+          shiny::showNotification(
+            paste(
+              "Stopped before the pending action.",
+              "No later boundary was crossed."
+            ),
+            type = "warning",
+            duration = 5
+          )
+        },
+        ignoreInit = TRUE
+      )
+    })
+
+    shiny::observeEvent(
+      input$reset_scenario,
+      {
+        if (identical(current()$status, "active")) {
+          return()
+        }
+        replacement <- tryCatch(
+          scenario_factory(example_dir),
+          error = function(error) {
+            shiny::showNotification(
+              conditionMessage(error),
+              type = "error",
+              duration = NULL
+            )
+            NULL
+          }
+        )
+        if (!is.null(replacement)) {
+          previous <- shiny::isolate(scenario())
+          scenario(replacement)
+          revision(revision() + 1L)
+          session$sendCustomMessage("ci-scroll-stage", list())
+          ci_scenario_close(previous)
+        }
+      },
+      ignoreInit = TRUE
+    )
+    invisible(list(advance_observers, stop_observers))
+  }
+}

--- a/inst/examples/continuous-intelligence/app/app.R
+++ b/inst/examples/continuous-intelligence/app/app.R
@@ -1,0 +1,31 @@
+required_packages <- c("bslib", "graft", "shiny", "tempest")
+missing_packages <- required_packages[
+  !vapply(required_packages, requireNamespace, logical(1), quietly = TRUE)
+]
+if (length(missing_packages) > 0L) {
+  stop(
+    "Install the app dependencies: ",
+    paste(missing_packages, collapse = ", ")
+  )
+}
+
+app_dir <- normalizePath(getwd(), mustWork = TRUE)
+example_dir <- normalizePath(file.path(app_dir, ".."), mustWork = TRUE)
+app_environment <- environment()
+for (path in c(
+  file.path(example_dir, "R", "host.R"),
+  file.path(example_dir, "R", "blue-sky.R"),
+  file.path(example_dir, "R", "scenario.R"),
+  file.path(app_dir, "R", "data.R"),
+  file.path(app_dir, "R", "presentation.R"),
+  file.path(app_dir, "R", "server.R")
+)) {
+  sys.source(path, envir = app_environment)
+}
+rm(app_environment, path)
+
+app <- shiny::shinyApp(
+  ui = ci_app_ui(),
+  server = ci_app_server(example_dir)
+)
+app

--- a/inst/examples/continuous-intelligence/app/www/briefing-room.css
+++ b/inst/examples/continuous-intelligence/app/www/briefing-room.css
@@ -1,0 +1,318 @@
+:root {
+  --blue-sky-ink: #163033;
+  --blue-sky-teal: #006e73;
+  --blue-sky-teal-soft: #dcebea;
+  --blue-sky-gold: #c88b35;
+  --blue-sky-paper: #fffdf8;
+  --blue-sky-line: #d9d2c4;
+  --blue-sky-muted: #657273;
+  --blue-sky-red: #ad3d38;
+}
+
+body {
+  letter-spacing: 0.005em;
+}
+
+.bslib-page-sidebar > .navbar {
+  border-bottom: 1px solid var(--blue-sky-line);
+  box-shadow: 0 4px 24px rgb(22 48 51 / 6%);
+}
+
+.app-title {
+  align-items: baseline;
+  display: flex;
+  font-size: 1.05rem;
+  font-weight: 700;
+  gap: 0.65rem;
+  letter-spacing: -0.02em;
+}
+
+.app-kicker,
+.stage-phase,
+.packet-label,
+.comparison-label {
+  color: var(--blue-sky-teal);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.stage-panel h2 {
+  font-size: 1.6rem;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+  margin: 0.55rem 0 1rem;
+}
+
+.stage-panel p,
+.guardrail-note p {
+  color: var(--blue-sky-muted);
+  line-height: 1.55;
+}
+
+.guardrail-note {
+  background: var(--blue-sky-teal-soft);
+  border-left: 4px solid var(--blue-sky-teal);
+  border-radius: 0.35rem;
+  padding: 1rem;
+}
+
+.guardrail-note p {
+  margin: 0.45rem 0 0;
+}
+
+.metric-box {
+  min-height: 118px;
+}
+
+.metric-box .value-box-value {
+  font-size: clamp(1.45rem, 2vw, 2.15rem);
+}
+
+.card {
+  border-color: var(--blue-sky-line);
+  box-shadow: 0 8px 28px rgb(22 48 51 / 6%);
+}
+
+.card-header {
+  align-items: center;
+  background: rgb(255 253 248 / 86%);
+  display: flex;
+  font-weight: 750;
+  justify-content: space-between;
+}
+
+.briefing-card {
+  background: var(--blue-sky-paper);
+}
+
+.briefing-markdown {
+  margin: 0 auto;
+  max-width: 780px;
+  padding: clamp(0.5rem, 2vw, 1.5rem);
+}
+
+.briefing-markdown h1 {
+  font-size: clamp(2rem, 5vw, 3.7rem);
+  letter-spacing: -0.055em;
+  line-height: 0.98;
+  margin-bottom: 0.6rem;
+}
+
+.briefing-markdown h2 {
+  border-top: 1px solid var(--blue-sky-line);
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  margin-top: 2rem;
+  padding-top: 1.15rem;
+  text-transform: uppercase;
+}
+
+.briefing-markdown p,
+.briefing-markdown li {
+  font-size: 1.04rem;
+  line-height: 1.65;
+}
+
+.status-badge {
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 0.3rem 0.6rem;
+  text-transform: uppercase;
+}
+
+.status-badge.is-waiting {
+  background: #ece7dd;
+  color: #5e625f;
+}
+
+.status-badge.is-signal {
+  background: #fff0d5;
+  color: #795111;
+}
+
+.status-badge.is-decision_trigger {
+  background: #f7dfdb;
+  color: #87352f;
+}
+
+.status-badge.is-no_material_change {
+  background: var(--blue-sky-teal-soft);
+  color: #145e60;
+}
+
+.scenario-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0.2rem 0;
+}
+
+.timeline-item {
+  align-items: center;
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: 12px 1fr auto;
+  padding: 0.65rem 0;
+}
+
+.timeline-marker {
+  background: #d1cbc0;
+  border: 2px solid var(--blue-sky-paper);
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px #aaa397;
+  height: 10px;
+  width: 10px;
+}
+
+.timeline-item.is-complete .timeline-marker {
+  background: var(--blue-sky-teal);
+  box-shadow: 0 0 0 1px var(--blue-sky-teal);
+}
+
+.timeline-item.is-current .timeline-marker {
+  background: var(--blue-sky-gold);
+  box-shadow: 0 0 0 3px rgb(200 139 53 / 22%);
+}
+
+.timeline-item.is-stopped .timeline-marker {
+  background: var(--blue-sky-red);
+  box-shadow: 0 0 0 3px rgb(173 61 56 / 18%);
+}
+
+.timeline-label {
+  font-weight: 650;
+}
+
+.timeline-status {
+  color: var(--blue-sky-muted);
+  font-size: 0.68rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.empty-state {
+  align-items: flex-start;
+  color: var(--blue-sky-muted);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 250px;
+  padding: 1.5rem;
+}
+
+.briefing-empty {
+  align-items: center;
+  min-height: 460px;
+  text-align: center;
+}
+
+.sunrise-mark {
+  background: var(--blue-sky-gold);
+  border-radius: 50% 50% 0 0;
+  height: 42px;
+  margin-bottom: 1.5rem;
+  width: 84px;
+}
+
+.decision-packet > p {
+  font-size: 1.02rem;
+  line-height: 1.55;
+  margin: 0.4rem 0 1.35rem;
+}
+
+.decision-options {
+  display: grid;
+  gap: 0.65rem;
+  list-style: none;
+  margin: 0.5rem 0 1.5rem;
+  padding: 0;
+}
+
+.decision-options li {
+  background: #f1eee7;
+  border-radius: 0.45rem;
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.8rem 1rem;
+}
+
+.decision-options span {
+  color: var(--blue-sky-muted);
+}
+
+.recommendation {
+  border-left: 4px solid var(--blue-sky-gold);
+  font-size: 1.15rem !important;
+  font-weight: 650;
+  padding-left: 1rem;
+}
+
+.decision-owner {
+  background: var(--blue-sky-teal-soft);
+  border-radius: 0.45rem;
+  line-height: 1.55;
+  padding: 1rem;
+}
+
+.comparison-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.comparison-card {
+  border: 1px solid var(--blue-sky-line);
+  border-radius: 0.6rem;
+  padding: 1.2rem;
+}
+
+.comparison-card h3 {
+  font-size: 1.1rem;
+  margin: 0.45rem 0 0.65rem;
+}
+
+.comparison-card p {
+  color: var(--blue-sky-muted);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.without-memory {
+  background: #f1eee7;
+}
+
+.with-memory {
+  background: var(--blue-sky-teal-soft);
+  border-color: #9ec7c5;
+}
+
+.table {
+  font-size: 0.82rem;
+}
+
+@media (max-width: 767px) {
+  .metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+
+  .briefing-markdown h1 {
+    font-size: 2.25rem;
+  }
+
+  .briefing-empty {
+    min-height: 300px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/inst/examples/continuous-intelligence/app/www/briefing-room.css
+++ b/inst/examples/continuous-intelligence/app/www/briefing-room.css
@@ -25,6 +25,7 @@ body {
   font-weight: 700;
   gap: 0.65rem;
   letter-spacing: -0.02em;
+  margin: 0;
 }
 
 .app-kicker,
@@ -83,6 +84,17 @@ body {
   justify-content: space-between;
 }
 
+.card-heading {
+  align-items: center;
+  display: flex;
+  font-size: inherit;
+  font-weight: inherit;
+  justify-content: space-between;
+  line-height: inherit;
+  margin: 0;
+  width: 100%;
+}
+
 .briefing-card {
   background: var(--blue-sky-paper);
 }
@@ -93,14 +105,14 @@ body {
   padding: clamp(0.5rem, 2vw, 1.5rem);
 }
 
-.briefing-markdown h1 {
+.briefing-markdown h3 {
   font-size: clamp(2rem, 5vw, 3.7rem);
   letter-spacing: -0.055em;
   line-height: 0.98;
   margin-bottom: 0.6rem;
 }
 
-.briefing-markdown h2 {
+.briefing-markdown h4 {
   border-top: 1px solid var(--blue-sky-line);
   font-size: 0.78rem;
   letter-spacing: 0.12em;
@@ -297,7 +309,7 @@ body {
     grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
   }
 
-  .briefing-markdown h1 {
+  .briefing-markdown h3 {
     font-size: 2.25rem;
   }
 

--- a/inst/examples/continuous-intelligence/run-demo.R
+++ b/inst/examples/continuous-intelligence/run-demo.R
@@ -15,160 +15,31 @@ example_dir <- if (
 
 source(file.path(example_dir, "R", "host.R"))
 source(file.path(example_dir, "R", "blue-sky.R"))
+source(file.path(example_dir, "R", "scenario.R"))
 
 run_continuous_intelligence_demo <- function(example_dir) {
-  profile <- ci_read_json(
-    file.path(example_dir, "profiles", "blue-sky.json")
-  )
-  schema <- graft::kg_schema(
-    file.path(example_dir, "schema", "blue-sky.graft.json")
-  )
-  store_path <- tempfile("blue-sky-", fileext = ".duckdb")
-  store <- graft::kg_connect_duckdb(schema, store_path)
-  on.exit(
-    {
-      graft::kg_disconnect(store)
-      unlink(store_path)
-    },
-    add = TRUE
-  )
-  graft::kg_init(store)
+  scenario <- ci_scenario_new(example_dir)
+  on.exit(ci_scenario_close(scenario), add = TRUE)
 
-  baseline <- jsonlite::fromJSON(
-    file.path(example_dir, "corpus", "baseline.json")
-  )
-  invisible(graft::kg_ingest(
-    store,
-    graft::kg_batch(
-      "blue-sky-demo",
-      idempotency_key = "blue-sky-baseline"
-    ),
-    baseline
-  ))
-
-  run_signal_day <- function(date, corpus_file) {
-    monitor_id <- paste0("blue-sky-monitor-", date)
-    review_id <- paste0("blue-sky-review-", date)
-    daily_bundle <- ci_read_json(
-      file.path(example_dir, "corpus", corpus_file)
-    )
-    monitor <- ci_run_monitor(
-      profile,
-      daily_bundle,
-      store,
-      monitor_id
-    )
-    cat(
-      tempest::tempest_run_artifact(
-        monitor,
-        "daily-briefing-md"
-      )@content,
-      "\n\n"
-    )
-    review <- ci_run_knowledge_review(
-      monitor,
-      monitor_id,
-      review_id,
-      store
-    )
-    committed <- ci_approve_and_commit(
-      review,
-      "knowledge-change-set-json",
-      store,
-      review_id,
-      "Approved source-faithful observations from the frozen corpus."
-    )
-    list(
-      monitor = monitor,
-      review = committed$run,
-      ingest = committed$ingest
-    )
+  while (identical(scenario$status, "active")) {
+    stage <- ci_scenario_stage(scenario)
+    if (identical(stage$format, "markdown")) {
+      cat(stage$detail, "\n\n")
+    }
+    if (identical(stage$id, "decision-approval")) {
+      cat("# Promoted workflow\n\n", stage$detail, "\n\n", sep = "")
+    }
+    ci_scenario_advance(scenario)
   }
 
-  day_one <- run_signal_day(
-    "2026-07-14",
-    "2026-07-14-supplier.json"
-  )
-  day_two <- run_signal_day(
-    "2026-07-15",
-    "2026-07-15-independent.json"
-  )
-
-  monitor_content <- tempest::tempest_run_artifact(
-    day_two$monitor,
-    "monitor-result-json"
-  )@content
-  referral <- monitor_content$referrals[[1L]]
-  promotion_store <- ci_promotion_store()
-  promotion_id <- ci_record_promotion(
-    promotion_store,
-    "blue-sky:promotion:prototype-gate:2026-07-15",
-    referral,
-    reviewer = "technology portfolio owner",
-    decided_at = "2026-07-15T13:30:00Z",
-    note = "Open the prototype-gate decision workflow."
-  )
-  decision <- ci_run_referral(
-    referral,
-    profile,
-    store,
-    blue_sky_result_builder,
-    "blue-sky-decision-2026-07-15",
-    promotion_store = promotion_store,
-    promotion_id = promotion_id
-  )
-  decision_content <- tempest::tempest_run_artifact(
-    decision,
-    "workflow-referral-result-json"
-  )@content
-  cat(
-    "# Promoted workflow\n\n",
-    decision_content$recommendation,
-    "\n\n",
-    sep = ""
-  )
-  committed_decision <- ci_approve_and_commit(
-    decision,
-    "workflow-referral-result-json",
-    store,
-    "blue-sky-decision-2026-07-15",
-    "Approved a bounded bench test; deployment remains unauthorized.",
-    record_mapper = blue_sky_decision_record_mapper
-  )
-
-  day_three <- ci_run_monitor(
-    profile,
-    ci_read_json(file.path(
-      example_dir,
-      "corpus",
-      "2026-07-16-no-change.json"
-    )),
-    store,
-    "blue-sky-monitor-2026-07-16"
-  )
-  cat(
-    tempest::tempest_run_artifact(
-      day_three,
-      "daily-briefing-md"
-    )@content,
-    "\n"
-  )
-
+  result <- ci_scenario_result(scenario)
   list(
-    monitor_runs = list(
-      day_one$monitor,
-      day_two$monitor,
-      day_three
-    ),
-    review_runs = list(day_one$review, day_two$review),
-    decision_run = committed_decision$run,
-    promotion_record = promotion_store$records[[promotion_id]],
-    assessment_count = nrow(dplyr::collect(
-      graft::kg_records(store, "Assessment")
-    )),
-    decision_count = nrow(dplyr::collect(
-      graft::kg_records(store, "ReviewDecision")
-    ))
+    monitor_runs = result$monitor_runs,
+    review_runs = result$review_runs,
+    decision_run = result$decision_run,
+    promotion_record = result$promotion_record,
+    assessment_count = result$assessment_count,
+    decision_count = result$decision_count
   )
 }
 

--- a/inst/examples/continuous-intelligence/walkthrough.R
+++ b/inst/examples/continuous-intelligence/walkthrough.R
@@ -30,6 +30,14 @@ sys.source(
   ),
   envir = walkthrough_environment
 )
+sys.source(
+  file.path(
+    continuous_intelligence_example_dir,
+    "R",
+    "scenario.R"
+  ),
+  envir = walkthrough_environment
+)
 rm(walkthrough_environment)
 
 ci_walkthrough_console_gate <- function(
@@ -97,363 +105,29 @@ ci_walkthrough_apply_gate <- function(
   decision
 }
 
-ci_walkthrough_result <- function(
-  state,
-  status,
-  stopped_at = NULL,
-  store = NULL
-) {
-  counts <- if (is.null(store)) {
-    list(
-      assessment_count = NA_integer_,
-      decision_count = NA_integer_
-    )
-  } else {
-    list(
-      assessment_count = nrow(dplyr::collect(
-        graft::kg_records(store, "Assessment")
-      )),
-      decision_count = nrow(dplyr::collect(
-        graft::kg_records(store, "ReviewDecision")
-      ))
-    )
-  }
-  c(
-    list(
-      status = status,
-      stopped_at = stopped_at
-    ),
-    state,
-    counts
-  )
-}
-
 run_continuous_intelligence_walkthrough <- function(
   example_dir = continuous_intelligence_example_dir,
   gate = ci_walkthrough_console_gate
 ) {
-  state <- list(
-    monitor_runs = list(),
-    review_runs = list(),
-    decision_run = NULL,
-    promotion_record = NULL,
-    ingests = list()
-  )
-  proceed <- ci_walkthrough_apply_gate(
-    gate,
-    "welcome",
-    "continue",
-    "Continuous intelligence: operator walkthrough",
-    paste(
-      "You are the technology executive for a themed-experience",
-      "organization. Over three simulated mornings, you will review",
-      "briefings, decide whether candidate knowledge can enter Graft,",
-      "promote a material referral, and approve or stop a bounded decision."
+  scenario <- ci_scenario_new(example_dir)
+  on.exit(ci_scenario_close(scenario), add = TRUE)
+
+  repeat {
+    stage <- ci_scenario_stage(scenario)
+    proceed <- ci_walkthrough_apply_gate(
+      gate,
+      stage$id,
+      stage$action,
+      stage$title,
+      stage$detail
     )
-  )
-  if (!proceed) {
-    return(ci_walkthrough_result(
-      state,
-      "stopped",
-      stopped_at = "welcome"
-    ))
+    if (!proceed) {
+      ci_scenario_stop(scenario)
+      return(ci_scenario_result(scenario))
+    }
+    ci_scenario_advance(scenario)
+    if (!identical(scenario$status, "active")) {
+      return(ci_scenario_result(scenario))
+    }
   }
-
-  profile <- ci_read_json(
-    file.path(example_dir, "profiles", "blue-sky.json")
-  )
-  schema <- graft::kg_schema(
-    file.path(example_dir, "schema", "blue-sky.graft.json")
-  )
-  store_path <- tempfile("blue-sky-walkthrough-", fileext = ".duckdb")
-  store <- graft::kg_connect_duckdb(schema, store_path)
-  on.exit(
-    {
-      graft::kg_disconnect(store)
-      unlink(store_path)
-    },
-    add = TRUE
-  )
-  graft::kg_init(store)
-
-  baseline <- jsonlite::fromJSON(
-    file.path(example_dir, "corpus", "baseline.json")
-  )
-  invisible(graft::kg_ingest(
-    store,
-    graft::kg_batch(
-      "blue-sky-walkthrough",
-      idempotency_key = "blue-sky-baseline"
-    ),
-    baseline
-  ))
-
-  run_signal_day <- function(date, corpus_file) {
-    monitor_id <- paste0("blue-sky-monitor-", date)
-    review_id <- paste0("blue-sky-review-", date)
-    daily_bundle <- ci_read_json(
-      file.path(example_dir, "corpus", corpus_file)
-    )
-    monitor <- ci_run_monitor(
-      profile,
-      daily_bundle,
-      store,
-      monitor_id
-    )
-    review <- ci_run_knowledge_review(
-      monitor,
-      monitor_id,
-      review_id,
-      store
-    )
-    list(
-      monitor_id = monitor_id,
-      review_id = review_id,
-      monitor = monitor,
-      review = review
-    )
-  }
-
-  day_one <- run_signal_day(
-    "2026-07-14",
-    "2026-07-14-supplier.json"
-  )
-  state$monitor_runs[[1L]] <- day_one$monitor
-  state$review_runs[[1L]] <- day_one$review
-  briefing <- tempest::tempest_run_artifact(
-    day_one$monitor,
-    "daily-briefing-md"
-  )@content
-  proceed <- ci_walkthrough_apply_gate(
-    gate,
-    "supplier-briefing",
-    "continue",
-    "Morning one: supplier signal",
-    briefing
-  )
-  if (!proceed) {
-    return(ci_walkthrough_result(
-      state,
-      "stopped",
-      stopped_at = "supplier-briefing",
-      store = store
-    ))
-  }
-
-  review_content <- tempest::tempest_run_artifact(
-    day_one$review,
-    "knowledge-change-set-json"
-  )@content
-  proceed <- ci_walkthrough_apply_gate(
-    gate,
-    "supplier-knowledge",
-    "approve",
-    "Knowledge boundary: supplier records",
-    paste(
-      ci_proposal_count(review_content$knowledge_changes),
-      paste(
-        "candidate records are awaiting approval.",
-        "They remain outside Graft until you approve this artifact."
-      )
-    )
-  )
-  if (!proceed) {
-    return(ci_walkthrough_result(
-      state,
-      "stopped",
-      stopped_at = "supplier-knowledge",
-      store = store
-    ))
-  }
-  committed <- ci_approve_and_commit(
-    day_one$review,
-    "knowledge-change-set-json",
-    store,
-    day_one$review_id,
-    "Approved source-faithful supplier observations."
-  )
-  state$review_runs[[1L]] <- committed$run
-  state$ingests[[1L]] <- committed$ingest
-
-  day_two <- run_signal_day(
-    "2026-07-15",
-    "2026-07-15-independent.json"
-  )
-  state$monitor_runs[[2L]] <- day_two$monitor
-  state$review_runs[[2L]] <- day_two$review
-  briefing <- tempest::tempest_run_artifact(
-    day_two$monitor,
-    "daily-briefing-md"
-  )@content
-  proceed <- ci_walkthrough_apply_gate(
-    gate,
-    "independent-briefing",
-    "continue",
-    "Morning two: independent evidence",
-    briefing
-  )
-  if (!proceed) {
-    return(ci_walkthrough_result(
-      state,
-      "stopped",
-      stopped_at = "independent-briefing",
-      store = store
-    ))
-  }
-
-  review_content <- tempest::tempest_run_artifact(
-    day_two$review,
-    "knowledge-change-set-json"
-  )@content
-  proceed <- ci_walkthrough_apply_gate(
-    gate,
-    "independent-knowledge",
-    "approve",
-    "Knowledge boundary: independent test records",
-    paste(
-      ci_proposal_count(review_content$knowledge_changes),
-      paste(
-        "candidate records are awaiting approval.",
-        "Approval accepts the observations and their evidence lineage,",
-        "but does not authorize a prototype or deployment."
-      )
-    )
-  )
-  if (!proceed) {
-    return(ci_walkthrough_result(
-      state,
-      "stopped",
-      stopped_at = "independent-knowledge",
-      store = store
-    ))
-  }
-  committed <- ci_approve_and_commit(
-    day_two$review,
-    "knowledge-change-set-json",
-    store,
-    day_two$review_id,
-    "Approved source-faithful independent observations."
-  )
-  state$review_runs[[2L]] <- committed$run
-  state$ingests[[2L]] <- committed$ingest
-
-  monitor_content <- tempest::tempest_run_artifact(
-    day_two$monitor,
-    "monitor-result-json"
-  )@content
-  referral <- monitor_content$referrals[[1L]]
-  proceed <- ci_walkthrough_apply_gate(
-    gate,
-    "workflow-promotion",
-    "promote",
-    "Promotion boundary: prototype-gate referral",
-    paste(
-      referral$reason,
-      paste0("Objective: ", referral$objective),
-      "Promotion opens a decision workflow; it does not approve its result.",
-      sep = "\n\n"
-    )
-  )
-  if (!proceed) {
-    return(ci_walkthrough_result(
-      state,
-      "stopped",
-      stopped_at = "workflow-promotion",
-      store = store
-    ))
-  }
-  promotion_store <- ci_promotion_store()
-  promotion_id <- ci_record_promotion(
-    promotion_store,
-    "blue-sky:promotion:prototype-gate:2026-07-15",
-    referral,
-    reviewer = "technology portfolio owner",
-    decided_at = "2026-07-15T13:30:00Z",
-    note = "Open the prototype-gate decision workflow."
-  )
-  state$promotion_record <- promotion_store$records[[promotion_id]]
-
-  decision <- ci_run_referral(
-    referral,
-    profile,
-    store,
-    blue_sky_result_builder,
-    "blue-sky-decision-2026-07-15",
-    promotion_store = promotion_store,
-    promotion_id = promotion_id
-  )
-  state$decision_run <- decision
-  decision_content <- tempest::tempest_run_artifact(
-    decision,
-    "workflow-referral-result-json"
-  )@content
-  proceed <- ci_walkthrough_apply_gate(
-    gate,
-    "decision-approval",
-    "approve",
-    "Decision boundary: bounded prototype test",
-    paste(
-      decision_content$recommendation,
-      paste(
-        "Approval commits the bounded decision and supersedes the prior",
-        "hold. It does not authorize deployment."
-      ),
-      sep = "\n\n"
-    )
-  )
-  if (!proceed) {
-    return(ci_walkthrough_result(
-      state,
-      "stopped",
-      stopped_at = "decision-approval",
-      store = store
-    ))
-  }
-  committed_decision <- ci_approve_and_commit(
-    decision,
-    "workflow-referral-result-json",
-    store,
-    "blue-sky-decision-2026-07-15",
-    "Approved a bounded bench test; deployment remains unauthorized.",
-    record_mapper = blue_sky_decision_record_mapper
-  )
-  state$decision_run <- committed_decision$run
-  state$ingests[[3L]] <- committed_decision$ingest
-
-  day_three <- ci_run_monitor(
-    profile,
-    ci_read_json(file.path(
-      example_dir,
-      "corpus",
-      "2026-07-16-no-change.json"
-    )),
-    store,
-    "blue-sky-monitor-2026-07-16"
-  )
-  state$monitor_runs[[3L]] <- day_three
-  briefing <- tempest::tempest_run_artifact(
-    day_three,
-    "daily-briefing-md"
-  )@content
-  proceed <- ci_walkthrough_apply_gate(
-    gate,
-    "no-change-briefing",
-    "continue",
-    "Morning three: no material change",
-    briefing
-  )
-  if (!proceed) {
-    return(ci_walkthrough_result(
-      state,
-      "stopped",
-      stopped_at = "no-change-briefing",
-      store = store
-    ))
-  }
-
-  ci_walkthrough_result(
-    state,
-    "completed",
-    store = store
-  )
 }

--- a/tests/testthat/test-continuous-intelligence-example.R
+++ b/tests/testthat/test-continuous-intelligence-example.R
@@ -308,6 +308,7 @@ test_that("briefing room app advances and resets isolated sessions", {
 
       expect_identical(current()$stage, "supplier-briefing")
       expect_identical(output$briefing_count, "1 / 3")
+      expect_identical(output$pending_count, "1")
       expect_match(
         environment$ci_app_latest_briefing(current()),
         "promising actuator claim"
@@ -329,6 +330,7 @@ test_that("briefing room app advances and resets isolated sessions", {
       session$setInputs(stop_supplier_briefing = 1)
       session$flushReact()
       expect_identical(current()$status, "stopped")
+      expect_identical(output$pending_count, "0")
 
       session$setInputs(stop_supplier_briefing = 2)
       session$flushReact()
@@ -339,6 +341,19 @@ test_that("briefing room app advances and resets isolated sessions", {
       expect_identical(current()$stage, "welcome")
       expect_identical(previous$closed, TRUE)
       expect_identical(file.exists(previous$store_path), FALSE)
+      expect_equal(
+        environment$ci_app_workflow_runs(current()),
+        data.frame(
+          Workflow = character(),
+          Status = character()
+        )
+      )
+      expect_identical(
+        environment$ci_app_scope_markdown_headings(
+          "# Brief\n\n## Detail"
+        ),
+        "### Brief\n\n#### Detail"
+      )
     }
   )
 })

--- a/tests/testthat/test-continuous-intelligence-example.R
+++ b/tests/testthat/test-continuous-intelligence-example.R
@@ -271,11 +271,88 @@ test_that("briefing scenario checkpoints accepted writes before later work", {
     tempest::tempest_run_status(scenario$state$review_runs[[1L]]),
     "succeeded"
   )
+  retry_stage <- environment$ci_scenario_stage(scenario)
+  expect_identical(retry_stage$action, "retry")
+  expect_identical(retry_stage$action_label, "Retry morning two")
 
   environment$ci_scenario_run_signal_day <- run_signal_day
   environment$ci_scenario_advance(scenario)
   expect_identical(scenario$stage, "independent-briefing")
   expect_length(scenario$state$ingests, 1L)
+})
+
+test_that("briefing scenario labels retries after later workflow failures", {
+  if (!continuous_intelligence_tempest_available()) {
+    testthat::skip(
+      "A compatible current Tempest workflow runtime is unavailable."
+    )
+  }
+  environment <- new.env(parent = globalenv())
+  for (path in c("host.R", "blue-sky.R", "scenario.R")) {
+    sys.source(
+      continuous_intelligence_example_path("R", path),
+      envir = environment
+    )
+  }
+  scenario <- environment$ci_scenario_new(
+    continuous_intelligence_example_path()
+  )
+  withr::defer(environment$ci_scenario_close(scenario))
+  for (index in seq_len(5L)) {
+    environment$ci_scenario_advance(scenario)
+  }
+  expect_identical(scenario$stage, "workflow-promotion")
+
+  run_referral <- environment$ci_run_referral
+  withr::defer({
+    environment$ci_run_referral <- run_referral
+  })
+  environment$ci_run_referral <- function(...) {
+    rlang::abort(
+      "Forced failure after workflow promotion.",
+      class = "ci_scenario_test_error"
+    )
+  }
+  expect_error(
+    environment$ci_scenario_advance(scenario),
+    class = "ci_scenario_test_error"
+  )
+  promotion <- scenario$state$promotion_record
+  retry_stage <- environment$ci_scenario_stage(scenario)
+  expect_identical(retry_stage$action, "retry")
+  expect_identical(
+    retry_stage$action_label,
+    "Retry decision workflow"
+  )
+
+  environment$ci_run_referral <- run_referral
+  environment$ci_scenario_advance(scenario)
+  expect_identical(scenario$stage, "decision-approval")
+  expect_identical(scenario$state$promotion_record, promotion)
+
+  run_monitor <- environment$ci_run_monitor
+  withr::defer({
+    environment$ci_run_monitor <- run_monitor
+  })
+  environment$ci_run_monitor <- function(...) {
+    rlang::abort(
+      "Forced failure after decision approval.",
+      class = "ci_scenario_test_error"
+    )
+  }
+  expect_error(
+    environment$ci_scenario_advance(scenario),
+    class = "ci_scenario_test_error"
+  )
+  expect_length(scenario$state$ingests, 3L)
+  retry_stage <- environment$ci_scenario_stage(scenario)
+  expect_identical(retry_stage$action, "retry")
+  expect_identical(retry_stage$action_label, "Retry morning three")
+
+  environment$ci_run_monitor <- run_monitor
+  environment$ci_scenario_advance(scenario)
+  expect_identical(scenario$stage, "no-change-briefing")
+  expect_length(scenario$state$ingests, 3L)
 })
 
 test_that("briefing room app advances and resets isolated sessions", {

--- a/tests/testthat/test-continuous-intelligence-example.R
+++ b/tests/testthat/test-continuous-intelligence-example.R
@@ -173,6 +173,176 @@ test_that("staged walkthrough exercises each operator boundary", {
   )
 })
 
+test_that("briefing scenario exposes resumable governed stages", {
+  if (!continuous_intelligence_tempest_available()) {
+    testthat::skip(
+      "A compatible current Tempest workflow runtime is unavailable."
+    )
+  }
+  environment <- new.env(parent = globalenv())
+  for (path in c("host.R", "blue-sky.R", "scenario.R")) {
+    sys.source(
+      continuous_intelligence_example_path("R", path),
+      envir = environment
+    )
+  }
+  scenario <- environment$ci_scenario_new(
+    continuous_intelligence_example_path()
+  )
+  withr::defer(environment$ci_scenario_close(scenario))
+
+  expect_identical(
+    environment$ci_scenario_stage(scenario)$id,
+    "welcome"
+  )
+  expect_identical(
+    environment$ci_scenario_timeline(scenario)$status,
+    c("current", rep("upcoming", 8L))
+  )
+  expect_equal(
+    environment$ci_scenario_counts(scenario),
+    list(assessment_count = 1L, decision_count = 1L)
+  )
+
+  environment$ci_scenario_advance(scenario)
+  environment$ci_scenario_advance(scenario)
+
+  expect_identical(
+    environment$ci_scenario_stage(scenario)$id,
+    "supplier-knowledge"
+  )
+  expect_length(scenario$state$monitor_runs, 1L)
+  expect_length(scenario$state$review_runs, 1L)
+  expect_length(scenario$state$ingests, 0L)
+  expect_identical(
+    tempest::tempest_run_status(scenario$state$review_runs[[1L]]),
+    "awaiting_approval"
+  )
+
+  environment$ci_scenario_stop(scenario)
+
+  expect_identical(scenario$status, "stopped")
+  expect_identical(scenario$stopped_at, "supplier-knowledge")
+  expect_length(scenario$state$ingests, 0L)
+  expect_identical(
+    environment$ci_scenario_timeline(scenario)$status[[3L]],
+    "stopped"
+  )
+})
+
+test_that("briefing scenario checkpoints accepted writes before later work", {
+  if (!continuous_intelligence_tempest_available()) {
+    testthat::skip(
+      "A compatible current Tempest workflow runtime is unavailable."
+    )
+  }
+  environment <- new.env(parent = globalenv())
+  for (path in c("host.R", "blue-sky.R", "scenario.R")) {
+    sys.source(
+      continuous_intelligence_example_path("R", path),
+      envir = environment
+    )
+  }
+  scenario <- environment$ci_scenario_new(
+    continuous_intelligence_example_path()
+  )
+  withr::defer(environment$ci_scenario_close(scenario))
+  environment$ci_scenario_advance(scenario)
+  environment$ci_scenario_advance(scenario)
+
+  run_signal_day <- environment$ci_scenario_run_signal_day
+  withr::defer({
+    environment$ci_scenario_run_signal_day <- run_signal_day
+  })
+  environment$ci_scenario_run_signal_day <- function(...) {
+    rlang::abort(
+      "Forced failure after the approval boundary.",
+      class = "ci_scenario_test_error"
+    )
+  }
+
+  expect_error(
+    environment$ci_scenario_advance(scenario),
+    class = "ci_scenario_test_error"
+  )
+  expect_identical(scenario$stage, "supplier-knowledge")
+  expect_length(scenario$state$ingests, 1L)
+  expect_identical(
+    tempest::tempest_run_status(scenario$state$review_runs[[1L]]),
+    "succeeded"
+  )
+
+  environment$ci_scenario_run_signal_day <- run_signal_day
+  environment$ci_scenario_advance(scenario)
+  expect_identical(scenario$stage, "independent-briefing")
+  expect_length(scenario$state$ingests, 1L)
+})
+
+test_that("briefing room app advances and resets isolated sessions", {
+  if (!continuous_intelligence_tempest_available()) {
+    testthat::skip(
+      "A compatible current Tempest workflow runtime is unavailable."
+    )
+  }
+  testthat::skip_if_not_installed("bslib", minimum_version = "0.9.0")
+  testthat::skip_if_not_installed("shiny", minimum_version = "1.11.1")
+  withr::local_options(sass.cache = FALSE)
+  app_dir <- continuous_intelligence_example_path("app")
+  withr::local_dir(app_dir)
+  environment <- new.env(parent = globalenv())
+  sys.source("app.R", envir = environment)
+
+  expect_s3_class(environment$app, "shiny.appobj")
+  expect_s3_class(environment$ci_app_ui(), "bslib_page")
+
+  shiny::testServer(
+    environment$ci_app_server(
+      continuous_intelligence_example_path()
+    ),
+    {
+      expect_identical(current()$stage, "welcome")
+      expect_identical(output$briefing_count, "0 / 3")
+
+      session$setInputs(advance_welcome = 1)
+      session$flushReact()
+
+      expect_identical(current()$stage, "supplier-briefing")
+      expect_identical(output$briefing_count, "1 / 3")
+      expect_match(
+        environment$ci_app_latest_briefing(current()),
+        "promising actuator claim"
+      )
+      expect_equal(
+        nrow(environment$ci_app_decision_records(current())),
+        1L
+      )
+      expect_equal(
+        nrow(environment$ci_app_decision_evidence(current())),
+        1L
+      )
+
+      session$setInputs(advance_welcome = 2)
+      session$flushReact()
+      expect_identical(current()$stage, "supplier-briefing")
+
+      previous <- current()
+      session$setInputs(stop_supplier_briefing = 1)
+      session$flushReact()
+      expect_identical(current()$status, "stopped")
+
+      session$setInputs(stop_supplier_briefing = 2)
+      session$flushReact()
+      expect_identical(current()$status, "stopped")
+
+      session$setInputs(reset_scenario = 1)
+      session$flushReact()
+      expect_identical(current()$stage, "welcome")
+      expect_identical(previous$closed, TRUE)
+      expect_identical(file.exists(previous$store_path), FALSE)
+    }
+  )
+})
+
 test_that("scheduled signals promote through approval into accepted history", {
   if (!continuous_intelligence_tempest_available()) {
     testthat::skip(


### PR DESCRIPTION
## Summary

- Add an installable Shiny Briefing Room that turns the provider-free three-morning continuous-intelligence scenario into an executive-facing walkthrough with briefing, decision, ledger, and audit views.
- Refactor the automatic demo and console walkthrough onto one example-local resumable scenario controller, preserving the existing Tempest proposal to host review to Graft ingest boundary without new public package APIs.
- Bind UI actions to exact scenario stages, checkpoint accepted writes before later work, isolate each Shiny session in a temporary Graft store, and cleanly support stop and reset behavior.
- Add responsive bslib presentation, safe Markdown rendering, formatted provenance tables, documentation, and regression coverage for approval boundaries, retries, stale actions, and cleanup.
- Harden the UI after a Playwright review by fixing the empty Audit-trail crash, reporting genuinely awaiting approvals, returning reset sessions to Morning brief, and providing a coherent heading hierarchy.
- Present downstream failures as retries when the preceding approval or promotion is already checkpointed, avoiding misleading duplicate-action language.

## Verification

- Run `devtools::load_all("../tempest"); devtools::load_all("."); shiny::runApp("inst/examples/continuous-intelligence/app")`, then advance through the supplier, independent-evidence, promoted-decision, and no-material-change mornings.
- 1,119 tests passed with a compatible development Tempest runtime.
- `devtools::check()`: 0 errors and 0 warnings; the local run reported one environment-only clock-verification note.
- `pkgdown::check_pkgdown()`: no problems.
- `air format . --check` and `git diff --check` passed.
- Playwright exercised the complete workflow, all four views, stop/reset behavior, keyboard tab navigation, full-screen cards, semantic headings, duplicate IDs, and 320 px, 390 px, and 1,280 px layouts with no horizontal overflow or console warnings or errors.
- Adversarial review found and fixed retry checkpointing, stale-action boundary crossing, session cleanup, and responsive presentation issues; no Blocking or Required findings remain.
