### PR TITLE
Add a dedicated Coworker pkgdown article

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Markdown deliverable. Tempest stops at the file-publication boundary. The
 approved file, approval decision, source links, and outcome memory enter Graft
 only after the operator approves the exact artifact:
 
+Read [Build a governed local
+Coworker](https://jameshwade.github.io/graft/articles/coworker.html) for the
+architecture, approval contract, model configuration, and tool-extension
+recipes.
+
 ```r
 example <- system.file(
   "examples",

--- a/README.md
+++ b/README.md
@@ -124,10 +124,9 @@ Markdown deliverable. Tempest stops at the file-publication boundary. The
 approved file, approval decision, source links, and outcome memory enter Graft
 only after the operator approves the exact artifact:
 
-Read [Build a governed local
-Coworker](https://jameshwade.github.io/graft/articles/coworker.html) for the
-architecture, approval contract, model configuration, and tool-extension
-recipes.
+Read [Build a governed local Coworker](https://jameshwade.github.io/graft/articles/coworker.html)
+for the architecture, approval contract, model configuration, and
+tool-extension recipes.
 
 ```r
 example <- system.file(

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -33,7 +33,7 @@ home:
 
 navbar:
   structure:
-    left: [intro, change_control, examples, reference, news]
+    left: [intro, change_control, coworker, examples, reference, news]
     right: [search, github, lightswitch]
   components:
     intro:
@@ -42,6 +42,9 @@ navbar:
     change_control:
       text: Change control
       href: articles/knowledge-change-control.html
+    coworker:
+      text: Coworker
+      href: articles/coworker.html
     examples:
       text: Examples
       href: articles/examples.html
@@ -66,6 +69,12 @@ articles:
       - getting-started
       - knowledge-change-control
       - linkml-schema
+  - title: Agent applications
+    desc: >
+      Build a local agent host with typed workflows, approval-gated actions,
+      accepted memory, configurable models, and extensible tools.
+    contents:
+      - coworker
   - title: Examples
     desc: >
       Small, runnable domain models adapted from established LinkML projects.

--- a/vignettes/coworker.Rmd
+++ b/vignettes/coworker.Rmd
@@ -253,8 +253,8 @@ finished local work product, review the exact publication, and make only the
 accepted outcome durable.
 
 Continue with [Getting started with Graft](getting-started.html) for the
-schema-to-store workflow, or [Govern knowledge
-changes](knowledge-change-control.html) for revision history and reviewed
-schema evolution. The complete Coworker implementation is available in the
-[source
-directory](https://github.com/JamesHWade/graft/tree/main/inst/examples/coworker).
+schema-to-store workflow, or
+[Govern knowledge changes](knowledge-change-control.html) for revision history
+and reviewed schema evolution. The complete Coworker implementation is
+available in the
+[source directory](https://github.com/JamesHWade/graft/tree/main/inst/examples/coworker).

--- a/vignettes/coworker.Rmd
+++ b/vignettes/coworker.Rmd
@@ -1,0 +1,260 @@
+---
+title: "Build a governed local Coworker"
+description: >
+  Combine Graft, Tempest, dsprrr, shinychat, and extensible ellmer tools in a
+  local agent that publishes and remembers work only after approval.
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Build a governed local Coworker}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+An agent demo can look impressive while leaving the important product
+questions unanswered. Which evidence may it use? Which tools may it call?
+What happens before a side effect? Which results become durable context for
+the next request?
+
+Graft Coworker is an installable local work-surface example inspired by
+[OpenWorker](https://github.com/andrewyng/openworker). It shows one answer for
+R applications:
+
+```text
+request -> plan -> reconcile evidence -> prepare deliverable
+        -> await approval -> publish file -> remember accepted outcome
+```
+
+The example is not a port of OpenWorker. It preserves the useful product
+contract---outcome-oriented work, a reviewable action, extensible tools, and
+continuity---while assigning each responsibility to an R package that already
+has the right abstraction.
+
+## Where each package fits
+
+| Component | Responsibility |
+|---|---|
+| **Shiny and bslib** | Multi-user-safe application shell, responsive work view, approval inbox, memory ledger, and activity view |
+| **shinychat and ellmer** | Conversation UI, model clients, and per-session tool loop |
+| **dsprrr** | One planner contract with deterministic and model-backed implementations |
+| **Tempest** | Typed workflow, artifacts, ordered events, and the approval pause before publication |
+| **Graft** | Schema-checked storage for approved runs, deliverables, decisions, source links, and workspace memory |
+
+The host application owns scheduling, routing, credentials, and side effects.
+Graft remains a workflow-generic knowledge layer; the example does not add
+Coworker-specific functions to the package API.
+
+## Run the complete loop without a model key
+
+From an installed package, locate and launch the example:
+
+```{r run-installed, eval = FALSE}
+library(graft)
+
+coworker <- system.file(
+  "examples",
+  "coworker",
+  package = "graft",
+  mustWork = TRUE
+)
+
+shiny::runApp(file.path(coworker, "app"))
+```
+
+Choose **Run provider-free example**. The deterministic dsprrr planner uses a
+bounded synthetic workspace containing GitHub, Jira, and Slack snapshots. It
+prepares a release-readiness brief, then stops before publishing the Markdown
+file.
+
+The four main views expose different parts of the contract:
+
+- **Work** shows the request, plan, source context, and finished deliverable.
+- **Inbox** shows the exact proposed action and file target.
+- **Memory** contains only outcomes accepted into Graft.
+- **Activity** shows ordered Tempest workflow and approval events.
+
+The provider-free path is useful for testing the complete lifecycle. It uses
+the same planner interface and workflow as a model-backed run, so replacing
+the planner does not change the approval or storage boundary.
+
+From a development checkout, load the current Tempest source before Graft:
+
+```{r run-checkout, eval = FALSE}
+devtools::load_all("../tempest")
+devtools::load_all(".")
+shiny::runApp("inst/examples/coworker/app")
+```
+
+## Treat approval as a data boundary
+
+Coworker does not use approval as a decorative confirmation dialog. Tempest
+pauses the workflow before its exporter runs. Graft remains unchanged until
+the operator decides what to do with the exact reviewed artifact.
+
+| Decision state | Local file | Graft records and memory |
+|---|---|---|
+| Awaiting approval | Not written | Not written |
+| Rejected | Not written | Not written |
+| Approved | Reviewed Markdown is written | Run, deliverable, decision, source links, and memory are committed atomically |
+
+Approval resumes the same Tempest run; it does not ask the planner to generate
+the deliverable again. The path shown in the Inbox comes from the same
+application helper used by the exporter, so the operator sees the file that
+will actually be written.
+
+The next request receives a bounded, deterministic view of accepted workspace
+memory. Drafts and rejected outcomes never become continuity context.
+
+This separation is the main reason to combine Tempest and Graft:
+
+- Tempest controls what may happen next in a running workflow.
+- Graft controls what accepted knowledge becomes durable and retrievable.
+
+## Configure models through Tempest
+
+The easiest model configuration remains Tempest's ambient option:
+
+```{r ambient-model, eval = FALSE}
+options(tempest.chat = "openai/gpt-5-mini")
+shiny::runApp(file.path(coworker, "app"))
+```
+
+`tempest.chat` may also be an ellmer `Chat` object. Coworker deep-clones the
+configured client for each browser session and uses a separate clone for the
+planner, preserving the original template and its provider instructions.
+
+Use a complete Tempest configuration when the assistant and planner need
+different models:
+
+```{r role-models, eval = FALSE}
+options(
+  graft.coworker.tempest_config = tempest::tempest_config(
+    models = list(
+      coordinator = "anthropic/claude-sonnet-4-20250514",
+      writer = "openai/gpt-5-mini"
+    )
+  )
+)
+```
+
+The Coworker assistant maps to Tempest's `coordinator` role and the dsprrr
+planner maps to `writer`. Tempest's normal precedence rules still apply: an
+explicit configuration wins over the ambient `tempest.chat` value, and an
+explicit `chat_fn` wins over model strings and templates. The `chat_fn` escape
+hatch supports an internal provider or any other custom ellmer client without
+changing the workflow.
+
+## Extend the tool registry
+
+Coworker always registers two governed core tools:
+
+- `prepare_outcome` starts the typed workflow and stops at approval; and
+- `recall_memory` performs bounded retrieval over accepted Graft memory.
+
+Add ordinary ellmer tools with an option:
+
+```{r add-tool, eval = FALSE}
+installed_package_version <- ellmer::tool(
+  function(package) as.character(utils::packageVersion(package)),
+  "Return the installed version of an R package.",
+  arguments = list(
+    package = ellmer::type_string("An installed R package name.")
+  ),
+  name = "installed_package_version"
+)
+
+options(
+  graft.coworker.tools = list(installed_package_version)
+)
+```
+
+A provider function can construct session-aware tools. It receives the current
+`worker`, `input`, `revision`, `session`, and `example_dir`:
+
+```{r tool-provider, eval = FALSE}
+options(
+  graft.coworker.tools = function(context) {
+    list(my_session_tool(context$session))
+  }
+)
+```
+
+Coworker rejects duplicate tool names instead of silently replacing a tool.
+This makes it safe to compose several tool providers while keeping the final
+registry inspectable.
+
+### Add the Posit `btw` tool belt
+
+The optional [posit-dev/btw](https://github.com/posit-dev/btw) integration can
+discover a broad R-aware tool collection:
+
+```{r btw-read-only, eval = FALSE}
+install.packages("btw")
+options(graft.coworker.btw = "read_only")
+```
+
+The `read_only` profile admits environment, documentation, file-reading, Git
+inspection, session, skill, CRAN, IDE, and web-reading tools. It excludes file
+edits, package execution, arbitrary R execution, Git mutations, GitHub API
+access, and subagents.
+
+Select btw groups or tool names for a smaller profile:
+
+```{r btw-subset, eval = FALSE}
+options(graft.coworker.btw = c("docs", "env", "sessioninfo"))
+```
+
+`options(graft.coworker.btw = "all")` exposes every locally available btw tool
+and is appropriate only for a trusted single-user environment.
+
+Directly registered mutating tools do not automatically pass through
+Coworker's publication approval. A production write tool should be a typed
+Tempest capability whose exact action and target can be shown before
+execution.
+
+## Replace the reference workspace
+
+The example keeps application concerns under `inst/examples/coworker/`:
+
+- `corpus/project-atlas.json` is the bounded reference source bundle;
+- `schema/coworker.linkml.yaml` defines the application-owned record contract;
+- `R/planner.R` defines the dsprrr planning interface;
+- `R/workflow.R` defines artifacts, approval, and publication;
+- `R/worker.R` owns the Graft store and approved ingestion; and
+- `app/` contains the Shiny host.
+
+A production host can replace the JSON bundle with authenticated read
+adapters, add Tempest capabilities for external actions, and preserve the same
+review boundary. Its record schema can evolve independently of Graft's package
+API.
+
+The default data directory is
+`file.path(tools::R_user_dir("graft", "data"), "coworker")`. Set
+`options(graft.coworker.data_dir = "/path")` or the
+`GRAFT_COWORKER_HOME` environment variable before launch to use another local
+directory.
+
+## Know the current boundary
+
+This is a vertical slice, not a desktop-agent replacement. It does not yet
+provide a desktop shell, background scheduling, OAuth connector catalog,
+durable chat transcripts, voice input, MCP client, or real Slack and calendar
+writes.
+
+Those are host features rather than missing Graft record functions. The
+current example is deliberately complete at one narrower boundary: prepare a
+finished local work product, review the exact publication, and make only the
+accepted outcome durable.
+
+Continue with [Getting started with Graft](getting-started.html) for the
+schema-to-store workflow, or [Govern knowledge
+changes](knowledge-change-control.html) for revision history and reviewed
+schema evolution. The complete Coworker implementation is available in the
+[source
+directory](https://github.com/JamesHWade/graft/tree/main/inst/examples/coworker).


### PR DESCRIPTION
## Summary

- Add a package-user-facing Coworker article covering its Graft, Tempest, dsprrr, shinychat, and ellmer architecture.
- Document the provider-free workflow, approval boundary, accepted memory, Tempest model configuration, custom tools, and the optional posit-dev/btw tool profile.
- Add Coworker to the pkgdown navbar and a dedicated Agent applications section, with a corresponding README link.

## Verification

- `pkgdown::build_article("coworker")`
- `pkgdown::check_pkgdown()`
- `pkgdown::build_site()`
- Desktop, 390px mobile, mobile navigation, and dark-mode browser review
- `devtools::check()` — 0 errors, 0 warnings, and the environment-only system-clock note