### PR TITLE
Harden live market briefing integration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,6 +5,7 @@
 ^\.DS_Store$
 ^\.venv$
 ^\.openai$
+^\.dsprrr_cache$
 ^AGENTS\.md$
 ^\.claude$
 ^[.]?air[.]toml$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ inst/doc
 /doc/
 /Meta/
 __pycache__/
+.dsprrr_cache/

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@
   with manifest validation and no arbitrary SQL.
 * `kg_store_info()` reports the store format, exact active schema build, and revision-history coverage in addition to connection and schema details; `kg_capabilities()` reports static backend capabilities.
 * `kg_sync_okf()` atomically materializes current accepted state into the store's managed OKF working tree without replacing unrelated directories.
-* `kg_tools()` creates seven read-only ellmer tools over bounded Graft retrieval APIs, including progressive access to current accepted OKF knowledge, with structured results and no arbitrary SQL surface.
+* `kg_tools()` creates seven read-only ellmer tools over bounded Graft retrieval APIs, including progressive access to current accepted OKF knowledge, with JSON-compatible structured results and no arbitrary SQL surface.
 * `kg_unresolved()` returns bounded unresolved mention records.
 * `kg_validate_data()` preflights the same staged identity, shape, and
   reference checks as ingestion without mutating the store.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # graft 0.0.0.9000
 
-* A governed Materials Market Radar example combines business, competitor, and downstream-market signals with dsprrr analysis, typed Tempest briefings and approval, configurable models and tools, and accepted-only Graft knowledge that visibly changes a later scan.
+* A governed Materials Market Radar example combines business, competitor, and downstream-market signals with dsprrr analysis, typed Tempest briefings and approval, configurable models and tools, a focused daily-brief and decision-room UI, and accepted-only Graft knowledge that visibly changes a later scan.
 * A local Graft Coworker example combines a shinychat tool-using assistant, dsprrr planning, typed Tempest work products, an approval inbox, local file delivery, and approved-only Graft memory. Its Tempest-native model configuration and extensible ellmer tool registry include an optional read-only `btw` tool belt.
 * A provider-free continuous-intelligence example, staged operator walkthrough, and interactive Shiny Briefing Room demonstrate scheduled Tempest briefings, host-bound promotion and approval, evidence-checked decisions, and governed Graft ingestion.
 * Store format 2 adds complete system-time revision history and rejects stores created by earlier development versions instead of silently upgrading or operating in a legacy mode.

--- a/R/agent-tools.R
+++ b/R/agent-tools.R
@@ -4,8 +4,9 @@
 #' one initialized store. The tools expose only graft's bounded retrieval
 #' functions; they do not accept SQL, file paths, URLs, or network options.
 #'
-#' Every tool returns the native graft result in `result` plus explicit
-#' `truncated`, `limit`, and `store_schema_digest` fields.
+#' Every tool returns a JSON-compatible representation of the graft result in
+#' `result` plus explicit `truncated`, `limit`, and `store_schema_digest`
+#' fields.
 #'
 #' @param store An initialized `kg_store`.
 #'
@@ -490,9 +491,16 @@ agent_tool_result <- function(
   store_schema_digest
 ) {
   list(
-    result = result,
+    result = agent_tool_json_result(result),
     truncated = isTRUE(truncated),
     limit = limit,
     store_schema_digest = store_schema_digest
   )
+}
+
+agent_tool_json_result <- function(result) {
+  if (is.list(result) && !is.data.frame(result)) {
+    return(unclass(result))
+  }
+  result
 }

--- a/R/okf.R
+++ b/R/okf.R
@@ -725,10 +725,10 @@ okf_record_body <- function(
     NULL
   }
   if (!is.null(statement)) {
-    citation_marks <- paste0("[^", sources$labels, "]", collapse = "")
+    citation_marks <- okf_citation_marks(sources$labels)
     lines <- c(lines, "", "## Statement", "", paste0(statement, citation_marks))
   } else if (!is.null(description)) {
-    citation_marks <- paste0("[^", sources$labels, "]", collapse = "")
+    citation_marks <- okf_citation_marks(sources$labels)
     lines <- c(lines, "", "## Summary", "", paste0(description, citation_marks))
   }
 
@@ -778,6 +778,13 @@ okf_record_body <- function(
     lines <- c(lines, "", footnotes)
   }
   paste(lines, collapse = "\n")
+}
+
+okf_citation_marks <- function(labels) {
+  if (length(labels) == 0L) {
+    return("")
+  }
+  paste0("[^", labels, "]", collapse = "")
 }
 
 okf_heading_text <- function(value) {

--- a/inst/examples/market-intelligence/R/planner.R
+++ b/inst/examples/market-intelligence/R/planner.R
@@ -14,6 +14,19 @@ mi_text <- function(value, field) {
   trimws(value)
 }
 
+mi_iso_date <- function(value, field) {
+  value <- mi_text(value, field)
+  parsed <- suppressWarnings(as.Date(value, format = "%Y-%m-%d"))
+  if (
+    !grepl("^[0-9]{4}-[0-9]{2}-[0-9]{2}$", value) ||
+      is.na(parsed) ||
+      !identical(format(parsed, "%Y-%m-%d"), value)
+  ) {
+    stop(paste0("`", field, "` must be a valid ISO date (YYYY-MM-DD)."))
+  }
+  value
+}
+
 mi_read_json <- function(path) {
   jsonlite::fromJSON(path, simplifyVector = FALSE)
 }
@@ -166,6 +179,7 @@ mi_model_planner <- function(chat) {
         "Return one bounded owner-assigned action.",
         "Use materiality values monitor, material, or urgent.",
         "Return confidence as a number between zero and one.",
+        "Return due_date as a valid ISO date in YYYY-MM-DD format.",
         "Return memory_used as yes only when accepted memory changed the readout.",
         "The Markdown briefing must include sources and the approval boundary."
       )
@@ -212,6 +226,7 @@ mi_run_planner <- function(planner, request, bundle, memory) {
       paste0("planner$", field)
     )
   }
+  result$due_date <- mi_iso_date(result$due_date, "planner$due_date")
   result$materiality <- match.arg(
     tolower(result$materiality),
     c("monitor", "material", "urgent")

--- a/inst/examples/market-intelligence/R/worker.R
+++ b/inst/examples/market-intelligence/R/worker.R
@@ -323,6 +323,7 @@ mi_worker_snapshot <- function(worker) {
       run_id = NULL,
       status = "ready",
       bundle_id = NULL,
+      scan_date = NULL,
       request = NULL,
       planning_engine = NULL,
       briefing = NULL,
@@ -339,6 +340,7 @@ mi_worker_snapshot <- function(worker) {
     run_id = run_id,
     status = tempest::tempest_run_status(run),
     bundle_id = metadata$bundle$bundle_id,
+    scan_date = metadata$bundle$scan_date,
     request = metadata$request,
     planning_engine = metadata$planning_engine,
     briefing = list(

--- a/inst/examples/market-intelligence/README.md
+++ b/inst/examples/market-intelligence/README.md
@@ -18,8 +18,8 @@ documents, an evidence-backed implication, and one accountable action.
   pause.
 - **Graft** stores the portfolio taxonomy and only approved observations,
   assessments, actions, source lineage, and run records.
-- **Shiny and bslib** provide the morning brief, portfolio map, review inbox,
-  knowledge ledger, and workflow audit.
+- **Shiny and bslib** provide a source-linked daily brief, a three-layer
+  decision room, the portfolio map, knowledge ledger, and workflow audit.
 
 The application owns its schema, sources, routing, schedule, model choice,
 tool registry, and side effects. It adds no market-specific Graft or Tempest
@@ -36,9 +36,9 @@ devtools::load_all(".")
 shiny::runApp("inst/examples/market-intelligence/app")
 ```
 
-The default path is provider-free. Select **Use configured model** before a
-scan to use the same dsprrr signature with the model configured through
-Tempest:
+The default path is provider-free. Open **Run settings** and select **Use
+configured model** before a scan to use the same dsprrr signature with the
+model configured through Tempest:
 
 ```r
 options(tempest.chat = "openai/gpt-5-mini")

--- a/inst/examples/market-intelligence/app/R/presentation.R
+++ b/inst/examples/market-intelligence/app/R/presentation.R
@@ -243,6 +243,13 @@ mi_app_metric <- function(label, value, detail, icon) {
   )
 }
 
+mi_app_display_date <- function(date) {
+  if (is.null(date) || !nzchar(date)) {
+    return("Awaiting scan")
+  }
+  format(as.Date(date), "%B %e, %Y")
+}
+
 mi_app_scan_controls <- function(progress, tool_count, can_run = TRUE) {
   next_bundle <- progress$next_bundle
   available <- !is.null(next_bundle)
@@ -274,15 +281,6 @@ mi_app_scan_controls <- function(progress, tool_count, can_run = TRUE) {
     ),
     shiny::tags$div(
       class = "mi-scan-actions",
-      bslib::input_switch(
-        "use_model",
-        "Use configured model",
-        value = FALSE
-      ),
-      shiny::tags$span(
-        class = "mi-tool-count",
-        paste(tool_count, if (tool_count == 1L) "tool" else "tools")
-      ),
       bslib::input_task_button(
         "run_scan",
         if (!can_run) {
@@ -294,6 +292,27 @@ mi_app_scan_controls <- function(progress, tool_count, can_run = TRUE) {
         },
         icon = bsicons::bs_icon("radar", `aria-hidden` = "true"),
         disabled = if (enabled) NULL else NA
+      ),
+      shiny::tags$details(
+        class = "mi-run-settings",
+        shiny::tags$summary(
+          bsicons::bs_icon("sliders", `aria-hidden` = "true"),
+          "Run settings"
+        ),
+        shiny::tags$div(
+          bslib::input_switch(
+            "use_model",
+            "Use configured model",
+            value = FALSE
+          ),
+          shiny::tags$span(
+            class = "mi-tool-count",
+            paste(tool_count, if (tool_count == 1L) "tool" else "tools")
+          ),
+          shiny::tags$p(
+            "Model selection stays in Tempest; tools come from the app registry."
+          )
+        )
       )
     )
   )
@@ -349,24 +368,77 @@ mi_app_briefing_card <- function(snapshot) {
     full_screen = TRUE,
     bslib::card_header(
       shiny::tags$div(
-        shiny::tags$span(class = "mi-eyebrow", "Executive briefing"),
+        shiny::tags$span(class = "mi-eyebrow", "Daily brief"),
         shiny::tags$h2(id = "mi-briefing-state", content$headline)
       ),
       mi_app_status_badge(snapshot$status)
     ),
     bslib::card_body(
       class = "mi-brief-body",
-      shiny::tags$p(class = "mi-lede", content$summary),
       shiny::tags$div(
-        class = "mi-insight-grid",
+        class = "mi-brief-sections",
         shiny::tags$section(
-          shiny::tags$h3("Why it matters"),
-          shiny::tags$p(content$implication)
+          shiny::tags$span(class = "mi-section-number", "01"),
+          shiny::tags$div(
+            shiny::tags$h3("What changed"),
+            shiny::tags$p(class = "mi-lede", content$summary)
+          )
         ),
         shiny::tags$section(
-          shiny::tags$h3("Continuity"),
-          shiny::tags$p(content$continuity)
+          shiny::tags$span(class = "mi-section-number", "02"),
+          shiny::tags$div(
+            shiny::tags$h3("Why it matters"),
+            shiny::tags$p(content$implication)
+          )
         )
+      ),
+      shiny::tags$section(
+        class = paste(
+          "mi-memory-effect",
+          if (isTRUE(content$memory_used)) "is-applied" else "is-first-read"
+        ),
+        shiny::tags$div(
+          class = "mi-memory-heading",
+          bsicons::bs_icon(
+            if (isTRUE(content$memory_used)) "layers-fill" else "layers",
+            `aria-hidden` = "true"
+          ),
+          shiny::tags$div(
+            shiny::tags$span(class = "mi-eyebrow", "Governed continuity"),
+            shiny::tags$h3("What accepted memory changed")
+          ),
+          shiny::tags$span(
+            class = "mi-memory-badge",
+            if (isTRUE(content$memory_used)) {
+              "Accepted memory applied"
+            } else {
+              "First read"
+            }
+          )
+        ),
+        shiny::tags$p(content$continuity)
+      ),
+      shiny::tags$section(
+        class = "mi-next-step",
+        shiny::tags$div(
+          class = "mi-next-step-icon",
+          bsicons::bs_icon("arrow-up-right", `aria-hidden` = "true")
+        ),
+        shiny::tags$div(
+          shiny::tags$span(class = "mi-eyebrow", "Proposed next step"),
+          shiny::tags$strong(content$action$title),
+          shiny::tags$small(
+            paste(content$action$owner, "· due", content$action$due_date)
+          )
+        ),
+        if (length(snapshot$pending) > 0L) {
+          shiny::actionButton(
+            "open_review",
+            "Review decision",
+            icon = bsicons::bs_icon("arrow-right", `aria-hidden` = "true"),
+            class = "btn-primary"
+          )
+        }
       ),
       shiny::tags$details(
         class = "mi-full-brief",
@@ -375,6 +447,56 @@ mi_app_briefing_card <- function(snapshot) {
           mi_app_scope_markdown_headings(snapshot$briefing$markdown)
         ))
       )
+    )
+  )
+}
+
+mi_app_brief_metrics <- function(snapshot) {
+  content <- snapshot$change_set
+  if (is.null(content)) {
+    return(list(
+      mi_app_metric("Materiality", "—", "Available after the scan", "flag"),
+      mi_app_metric("Confidence", "—", "Available after the scan", "bullseye"),
+      mi_app_metric(
+        "Evidence",
+        "—",
+        "Sources stay linked",
+        "file-earmark-text"
+      ),
+      mi_app_metric("Memory effect", "—", "Accepted knowledge only", "layers")
+    ))
+  }
+  list(
+    mi_app_metric(
+      "Materiality",
+      tools::toTitleCase(content$materiality),
+      "Requires a human decision",
+      "flag"
+    ),
+    mi_app_metric(
+      "Confidence",
+      paste0(round(content$confidence * 100), "%"),
+      "Planner assessment",
+      "bullseye"
+    ),
+    mi_app_metric(
+      "Evidence",
+      length(content$observations),
+      paste(
+        length(content$sources),
+        if (length(content$sources) == 1L) "linked source" else "linked sources"
+      ),
+      "file-earmark-text"
+    ),
+    mi_app_metric(
+      "Memory effect",
+      if (isTRUE(content$memory_used)) "Applied" else "First read",
+      if (isTRUE(content$memory_used)) {
+        "Accepted Graft history informed this brief"
+      } else {
+        "No accepted thesis informed this brief"
+      },
+      "layers"
     )
   )
 }
@@ -427,16 +549,12 @@ mi_app_evidence_card <- function(snapshot) {
   )
 }
 
-mi_app_briefing_view <- function(
-  worker,
-  snapshot,
-  progress,
-  tool_count
-) {
-  business_count <- nrow(mi_worker_records(worker, "Business"))
-  assessment_count <- nrow(mi_worker_records(worker, "Assessment"))
-  action_count <- nrow(mi_worker_records(worker, "IntelligenceAction"))
-  pending_count <- length(snapshot$pending)
+mi_app_briefing_view <- function(snapshot, progress, tool_count) {
+  current_date <- mi_or(
+    snapshot$scan_date,
+    if (!is.null(progress$next_bundle)) progress$next_bundle$scan_date
+  )
+  metrics <- mi_app_brief_metrics(snapshot)
   shiny::tagList(
     shiny::tags$header(
       class = "mi-hero",
@@ -444,19 +562,19 @@ mi_app_briefing_view <- function(
         shiny::tags$span(class = "mi-eyebrow", "Morning intelligence"),
         shiny::tags$h1(
           id = "mi-page-title",
-          "See the market as a connected system."
+          "Your daily market brief."
         ),
         shiny::tags$p(
           paste(
-            "Signals become useful only when they connect to a business,",
-            "competitor, downstream market, accountable action, and outcome."
+            "A source-linked view of what changed across Dow's businesses,",
+            "competitors, and downstream markets—then one bounded decision."
           )
         )
       ),
       shiny::tags$div(
         class = "mi-hero-date",
-        shiny::tags$span("Demo horizon"),
-        shiny::tags$strong("July 2026")
+        shiny::tags$span("Briefing date"),
+        shiny::tags$strong(mi_app_display_date(current_date))
       )
     ),
     mi_app_scan_controls(
@@ -467,34 +585,10 @@ mi_app_briefing_view <- function(
     bslib::layout_column_wrap(
       width = "220px",
       fill = FALSE,
-      mi_app_metric(
-        "Portfolio coverage",
-        business_count,
-        "Global businesses in the graph",
-        "boxes"
-      ),
-      mi_app_metric(
-        "Accepted theses",
-        assessment_count,
-        "Reviewed assessments in Graft",
-        "check2-circle"
-      ),
-      mi_app_metric(
-        "Open actions",
-        action_count,
-        "Owner-assigned follow-ups",
-        "arrow-up-right-circle"
-      ),
-      mi_app_metric(
-        "Review inbox",
-        pending_count,
-        if (pending_count == 1L) {
-          "Assessment needs a decision"
-        } else {
-          "Nothing waiting for approval"
-        },
-        "inbox"
-      )
+      metrics[[1L]],
+      metrics[[2L]],
+      metrics[[3L]],
+      metrics[[4L]]
     ),
     bslib::layout_columns(
       col_widths = c(8, 4),
@@ -601,12 +695,15 @@ mi_app_review_view <- function(snapshot) {
   shiny::tagList(
     shiny::tags$header(
       class = "mi-section-header",
-      shiny::tags$span(class = "mi-eyebrow", "Approval boundary"),
-      shiny::tags$h2(id = "mi-review-title", "Review before interpretation"),
+      shiny::tags$span(class = "mi-eyebrow", "Decision room"),
+      shiny::tags$h2(
+        id = "mi-review-title",
+        "Decide what becomes organizational memory"
+      ),
       shiny::tags$p(
         paste(
-          "The public evidence is inspectable now. The assessment, action,",
-          "and durable organizational memory remain pending."
+          "Trace the line from source-faithful observations to interpretation",
+          "and action before anything enters Graft."
         )
       )
     ),
@@ -623,21 +720,63 @@ mi_app_review_view <- function(snapshot) {
         class = "mi-review-card",
         bslib::card_header(
           shiny::tags$div(
-            shiny::tags$span(class = "mi-eyebrow", "Proposed assessment"),
+            shiny::tags$span(class = "mi-eyebrow", "Decision packet"),
             shiny::tags$h3(id = "mi-review-state", content$headline)
           ),
           mi_app_status_badge("awaiting_approval")
         ),
         bslib::card_body(
           shiny::tags$div(
-            class = "mi-review-grid",
-            shiny::tags$section(
-              shiny::tags$h4("Assessment"),
-              shiny::tags$p(content$summary),
-              shiny::tags$h4("Implication"),
-              shiny::tags$p(content$implication)
+            class = "mi-review-flow",
+            shiny::tags$article(
+              class = "mi-review-layer is-observed",
+              shiny::tags$header(
+                shiny::tags$span(class = "mi-review-step", "01"),
+                shiny::tags$div(
+                  shiny::tags$span(class = "mi-eyebrow", "Evidence"),
+                  shiny::tags$h4("Observed")
+                )
+              ),
+              shiny::tags$p(
+                class = "mi-layer-intro",
+                "Source-faithful signals; no organizational judgment yet."
+              ),
+              shiny::tags$ol(
+                class = "mi-review-observations",
+                lapply(
+                  content$observations,
+                  \(observation) {
+                    shiny::tags$li(
+                      shiny::tags$span(
+                        class = paste0(
+                          "mi-direction is-",
+                          observation$direction
+                        ),
+                        observation$direction
+                      ),
+                      shiny::tags$p(observation$statement)
+                    )
+                  }
+                )
+              ),
+              shiny::tags$div(
+                class = "mi-review-sources",
+                shiny::tags$h5("Linked sources"),
+                mi_app_source_list(content$sources)
+              )
             ),
-            shiny::tags$aside(
+            shiny::tags$article(
+              class = "mi-review-layer is-interpreted",
+              shiny::tags$header(
+                shiny::tags$span(class = "mi-review-step", "02"),
+                shiny::tags$div(
+                  shiny::tags$span(class = "mi-eyebrow", "Assessment"),
+                  shiny::tags$h4("Interpreted")
+                )
+              ),
+              shiny::tags$p(class = "mi-layer-intro", content$summary),
+              shiny::tags$h5("Why it matters"),
+              shiny::tags$p(content$implication),
               shiny::tags$dl(
                 shiny::tags$div(
                   shiny::tags$dt("Materiality"),
@@ -648,7 +787,39 @@ mi_app_review_view <- function(snapshot) {
                   shiny::tags$dd(
                     paste0(round(content$confidence * 100), "%")
                   )
+                )
+              ),
+              shiny::tags$section(
+                class = "mi-review-memory",
+                shiny::tags$span("Effect of accepted memory"),
+                shiny::tags$p(content$continuity)
+              )
+            ),
+            shiny::tags$article(
+              class = "mi-review-layer is-proposed",
+              shiny::tags$header(
+                shiny::tags$span(class = "mi-review-step", "03"),
+                shiny::tags$div(
+                  shiny::tags$span(class = "mi-eyebrow", "Next step"),
+                  shiny::tags$h4("Proposed")
+                )
+              ),
+              shiny::tags$p(
+                class = "mi-layer-intro",
+                "A bounded follow-up with an accountable owner and date."
+              ),
+              shiny::tags$div(
+                class = "mi-proposed-action",
+                bsicons::bs_icon(
+                  "arrow-right-circle",
+                  `aria-hidden` = "true"
                 ),
+                shiny::tags$div(
+                  shiny::tags$span("Action"),
+                  shiny::tags$strong(content$action$title)
+                )
+              ),
+              shiny::tags$dl(
                 shiny::tags$div(
                   shiny::tags$dt("Owner"),
                   shiny::tags$dd(content$action$owner)
@@ -661,11 +832,39 @@ mi_app_review_view <- function(snapshot) {
             )
           ),
           shiny::tags$section(
-            class = "mi-proposed-action",
-            bsicons::bs_icon("arrow-right-circle", `aria-hidden` = "true"),
+            class = "mi-review-consequences",
+            `aria-labelledby` = "mi-consequences-title",
+            shiny::tags$h4(
+              id = "mi-consequences-title",
+              "What your decision does"
+            ),
             shiny::tags$div(
-              shiny::tags$span("Proposed action"),
-              shiny::tags$strong(content$action$title)
+              shiny::tags$article(
+                class = "is-approve",
+                bsicons::bs_icon("check2-circle", `aria-hidden` = "true"),
+                shiny::tags$div(
+                  shiny::tags$strong("Approve and save"),
+                  shiny::tags$p(
+                    paste(
+                      "Commit this assessment, action, evidence, and run to",
+                      "Graft. Future briefs may use it."
+                    )
+                  )
+                )
+              ),
+              shiny::tags$article(
+                class = "is-reject",
+                bsicons::bs_icon("x-circle", `aria-hidden` = "true"),
+                shiny::tags$div(
+                  shiny::tags$strong("Reject proposal"),
+                  shiny::tags$p(
+                    paste(
+                      "Record the rejection in Tempest. Accepted Graft memory",
+                      "remains unchanged."
+                    )
+                  )
+                )
+              )
             )
           ),
           shiny::tags$label(
@@ -686,13 +885,13 @@ mi_app_review_view <- function(snapshot) {
           class = "mi-review-actions",
           shiny::actionButton(
             "reject_assessment",
-            "Reject",
+            "Reject proposal",
             icon = bsicons::bs_icon("x-lg", `aria-hidden` = "true"),
             class = "btn-outline-danger"
           ),
           shiny::actionButton(
             "approve_assessment",
-            "Approve into Graft",
+            "Approve and save to Graft",
             icon = bsicons::bs_icon("check2", `aria-hidden` = "true"),
             class = "btn-success"
           )

--- a/inst/examples/market-intelligence/app/R/server.R
+++ b/inst/examples/market-intelligence/app/R/server.R
@@ -70,7 +70,6 @@ mi_app_server <- function(
 
     output$briefing_view <- shiny::renderUI({
       mi_app_briefing_view(
-        worker(),
         current_snapshot(),
         current_progress(),
         length(configured_tools)
@@ -167,6 +166,15 @@ mi_app_server <- function(
           ),
           type = "message"
         )
+      },
+      ignoreInit = TRUE
+    )
+
+    shiny::observeEvent(
+      input$open_review,
+      {
+        bslib::nav_select("active_view", "review", session = session)
+        focus_after_flush("mi-review-state")
       },
       ignoreInit = TRUE
     )

--- a/inst/examples/market-intelligence/app/www/market-intelligence.css
+++ b/inst/examples/market-intelligence/app/www/market-intelligence.css
@@ -379,11 +379,68 @@ a:hover {
   font-weight: 700;
 }
 
+.mi-run-settings {
+  position: relative;
+}
+
+.mi-run-settings > summary {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.65rem;
+  color: var(--mi-muted);
+  cursor: pointer;
+  font-size: 0.74rem;
+  font-weight: 650;
+  list-style: none;
+}
+
+.mi-run-settings > summary::-webkit-details-marker {
+  display: none;
+}
+
+.mi-run-settings > summary:hover {
+  background: var(--mi-surface-subtle);
+  color: var(--mi-ink);
+}
+
+.mi-run-settings[open] > summary {
+  background: var(--mi-surface-subtle);
+  color: var(--mi-primary);
+}
+
+.mi-run-settings > div {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 0.55rem);
+  right: 0;
+  display: grid;
+  width: 19rem;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--mi-border);
+  border-radius: 0.8rem;
+  background: var(--mi-surface);
+  box-shadow: var(--mi-shadow);
+}
+
+.mi-run-settings .form-check {
+  white-space: normal;
+}
+
+.mi-run-settings p {
+  margin: 0;
+  color: var(--mi-muted);
+  font-size: 0.7rem;
+}
+
 .bslib-value-box.mi-metric {
   min-height: 9.4rem;
   border: 1px solid var(--mi-border);
   border-radius: 1rem;
-  background: var(--mi-surface);
+  background: var(--mi-surface) !important;
   box-shadow: none;
   color: var(--mi-ink);
 }
@@ -463,25 +520,177 @@ a:hover {
   line-height: 1.65;
 }
 
-.mi-insight-grid {
+.mi-brief-sections {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0;
-  margin: 1.3rem 0;
-  border: 1px solid var(--mi-border);
-  border-radius: 0.8rem;
-  overflow: hidden;
+  border-bottom: 1px solid var(--mi-border);
 }
 
-.mi-insight-grid section {
-  padding: 1rem;
+.mi-brief-sections section {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr);
+  gap: 0.65rem;
+  padding: 0.3rem 1.1rem 1.35rem 0;
 }
 
-.mi-insight-grid section + section {
+.mi-brief-sections section + section {
+  padding-left: 1.1rem;
   border-left: 1px solid var(--mi-border);
 }
 
-.mi-insight-grid h3,
+.mi-section-number,
+.mi-review-step {
+  display: inline-grid;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid var(--mi-border);
+  border-radius: 999px;
+  background: var(--mi-surface-subtle);
+  color: var(--mi-muted);
+  font-size: 0.62rem;
+  font-weight: 800;
+  place-items: center;
+}
+
+.mi-brief-sections h3 {
+  margin: 0 0 0.45rem;
+  color: var(--mi-ink);
+  font-size: 0.78rem;
+  font-weight: 780;
+  letter-spacing: 0.01em;
+}
+
+.mi-brief-sections p {
+  margin: 0;
+  color: var(--mi-muted);
+  font-size: 0.84rem;
+  line-height: 1.58;
+}
+
+.mi-brief-sections .mi-lede {
+  color: var(--mi-ink);
+  font-size: 0.96rem;
+}
+
+.mi-memory-effect {
+  margin-top: 1.1rem;
+  padding: 1rem;
+  border: 1px solid var(--mi-border);
+  border-left: 4px solid var(--mi-muted);
+  border-radius: 0.8rem;
+  background: var(--mi-surface-subtle);
+}
+
+.mi-memory-effect.is-applied {
+  border-left-color: var(--mi-primary);
+  background: color-mix(
+    in srgb,
+    var(--mi-primary-soft) 58%,
+    var(--mi-surface)
+  );
+}
+
+.mi-memory-heading {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.7rem;
+  align-items: center;
+}
+
+.mi-memory-heading > svg {
+  color: var(--mi-primary);
+}
+
+.mi-memory-heading .mi-eyebrow {
+  margin-bottom: 0.1rem;
+  font-size: 0.58rem;
+}
+
+.mi-memory-heading h3 {
+  margin: 0;
+  color: var(--mi-ink);
+  font-size: 0.82rem;
+}
+
+.mi-memory-badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: var(--mi-surface);
+  color: var(--mi-muted);
+  font-size: 0.63rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.mi-memory-effect > p {
+  margin: 0.7rem 0 0 1.7rem;
+  color: var(--mi-muted);
+  font-size: 0.78rem;
+}
+
+.mi-next-step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.8rem;
+  align-items: center;
+  margin-top: 1rem;
+  padding: 0.9rem;
+  border-radius: 0.8rem;
+  background: var(--mi-primary-strong);
+  color: #fff;
+}
+
+[data-bs-theme="dark"] .mi-next-step {
+  background: #214b3f;
+}
+
+.mi-next-step-icon {
+  display: grid;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.12);
+  place-items: center;
+}
+
+.mi-next-step > div:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.mi-next-step .mi-eyebrow {
+  margin-bottom: 0.12rem;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.58rem;
+}
+
+.mi-next-step strong {
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.mi-next-step small {
+  margin-top: 0.2rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.66rem;
+}
+
+.mi-next-step .btn {
+  border-color: #fff;
+  background: #fff;
+  color: #17473c;
+  font-size: 0.74rem;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.mi-next-step .btn:hover {
+  border-color: var(--mi-primary-soft);
+  background: var(--mi-primary-soft);
+  color: #17473c;
+}
+
 .mi-evidence-card h3,
 .mi-business-list h3,
 .mi-market-grid h3 {
@@ -491,7 +700,6 @@ a:hover {
   font-weight: 750;
 }
 
-.mi-insight-grid p,
 .mi-business-list p,
 .mi-market-grid p {
   margin: 0;
@@ -717,7 +925,7 @@ a:hover {
 }
 
 .mi-review-card {
-  max-width: 66rem;
+  max-width: 78rem;
   margin: 0 auto;
   box-shadow: var(--mi-shadow);
 }
@@ -726,56 +934,6 @@ a:hover {
   margin: 0;
   font-size: 1.15rem;
   line-height: 1.25;
-}
-
-.mi-review-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 16rem;
-  gap: 1.5rem;
-}
-
-.mi-review-grid h4 {
-  margin: 0 0 0.35rem;
-  color: var(--mi-muted);
-  font-size: 0.68rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.mi-review-grid p {
-  margin: 0 0 1.2rem;
-}
-
-.mi-review-grid aside {
-  padding: 1rem;
-  border-radius: 0.8rem;
-  background: var(--mi-surface-subtle);
-}
-
-.mi-review-grid dl {
-  display: grid;
-  gap: 0.7rem;
-  margin: 0;
-}
-
-.mi-review-grid dl > div {
-  display: flex;
-  justify-content: space-between;
-  border-bottom: 1px solid var(--mi-border);
-}
-
-.mi-review-grid dt {
-  color: var(--mi-muted);
-  font-size: 0.72rem;
-  font-weight: 600;
-}
-
-.mi-review-grid dd {
-  color: var(--mi-ink);
-  font-size: 0.74rem;
-  font-weight: 700;
-  text-transform: capitalize;
 }
 
 .mi-proposed-action {
@@ -818,6 +976,192 @@ a:hover {
   border-radius: 0.68rem;
   font-size: 0.8rem;
   font-weight: 700;
+}
+
+.mi-review-flow {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--mi-border);
+  border-radius: 0.9rem;
+  overflow: hidden;
+}
+
+.mi-review-layer {
+  min-width: 0;
+  padding: 1.1rem;
+}
+
+.mi-review-layer + .mi-review-layer {
+  border-left: 1px solid var(--mi-border);
+}
+
+.mi-review-layer > header {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.mi-review-layer .mi-eyebrow {
+  margin-bottom: 0.05rem;
+  font-size: 0.58rem;
+}
+
+.mi-review-layer h4 {
+  margin: 0;
+  color: var(--mi-ink);
+  font-size: 1rem;
+}
+
+.mi-review-layer h5,
+.mi-review-sources h5 {
+  margin: 1rem 0 0.35rem;
+  color: var(--mi-muted);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mi-layer-intro,
+.mi-review-layer > p {
+  margin: 0.9rem 0 0;
+  color: var(--mi-ink);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.mi-layer-intro {
+  color: var(--mi-muted);
+}
+
+.mi-review-observations {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mi-review-observations li {
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--mi-border);
+}
+
+.mi-review-observations p {
+  margin: 0.3rem 0 0;
+  color: var(--mi-ink);
+  font-size: 0.73rem;
+  line-height: 1.45;
+}
+
+.mi-review-sources {
+  padding-top: 0.1rem;
+}
+
+.mi-review-layer dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin: 1rem 0 0;
+}
+
+.mi-review-layer dl > div {
+  padding: 0.65rem;
+  border-radius: 0.65rem;
+  background: var(--mi-surface-subtle);
+}
+
+.mi-review-layer dt {
+  color: var(--mi-muted);
+  font-size: 0.62rem;
+  font-weight: 650;
+}
+
+.mi-review-layer dd {
+  margin: 0.15rem 0 0;
+  color: var(--mi-ink);
+  font-size: 0.72rem;
+  font-weight: 750;
+  text-transform: capitalize;
+}
+
+.mi-review-layer .mi-proposed-action {
+  align-items: flex-start;
+  margin-top: 1rem;
+}
+
+.mi-review-memory {
+  margin-top: 1rem;
+  padding: 0.8rem;
+  border-left: 3px solid var(--mi-primary);
+  background: var(--mi-primary-soft);
+}
+
+.mi-review-memory span {
+  color: var(--mi-primary-strong);
+  font-size: 0.62rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.mi-review-memory p {
+  margin: 0.3rem 0 0;
+  color: var(--mi-ink);
+  font-size: 0.72rem;
+}
+
+.mi-review-consequences {
+  margin-top: 1.2rem;
+}
+
+.mi-review-consequences > h4 {
+  margin: 0 0 0.55rem;
+  color: var(--mi-ink);
+  font-size: 0.78rem;
+}
+
+.mi-review-consequences > div {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.mi-review-consequences article {
+  display: flex;
+  gap: 0.7rem;
+  padding: 0.8rem;
+  border: 1px solid var(--mi-border);
+  border-radius: 0.75rem;
+}
+
+.mi-review-consequences .is-approve {
+  border-color: color-mix(in srgb, var(--mi-positive) 35%, var(--mi-border));
+  background: var(--mi-positive-soft);
+}
+
+.mi-review-consequences .is-reject {
+  background: var(--mi-surface-subtle);
+}
+
+.mi-review-consequences .is-approve > svg {
+  color: var(--mi-positive);
+}
+
+.mi-review-consequences .is-reject > svg {
+  color: var(--mi-muted);
+}
+
+.mi-review-consequences strong {
+  display: block;
+  color: var(--mi-ink);
+  font-size: 0.73rem;
+}
+
+.mi-review-consequences p {
+  margin: 0.18rem 0 0;
+  color: var(--mi-muted);
+  font-size: 0.68rem;
+  line-height: 1.4;
 }
 
 .mi-ledger {
@@ -1014,6 +1358,15 @@ a:hover {
     flex-wrap: wrap;
   }
 
+  .mi-review-flow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mi-review-layer + .mi-review-layer {
+    border-top: 1px solid var(--mi-border);
+    border-left: 0;
+  }
+
   .mi-market-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -1037,14 +1390,24 @@ a:hover {
     margin-top: 1rem;
   }
 
-  .mi-insight-grid,
-  .mi-review-grid {
+  .mi-brief-sections {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .mi-insight-grid section + section {
+  .mi-brief-sections section + section {
+    padding-top: 1.1rem;
+    padding-left: 0;
     border-top: 1px solid var(--mi-border);
     border-left: 0;
+  }
+
+  .mi-next-step {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .mi-next-step .btn {
+    grid-column: 1 / -1;
+    min-height: 42px;
   }
 
   .mi-business-list {
@@ -1103,8 +1466,18 @@ a:hover {
     grid-template-columns: 1fr auto;
   }
 
-  .mi-scan-actions .form-check {
-    grid-column: 1 / -1;
+  .mi-run-settings {
+    min-width: 0;
+  }
+
+  .mi-run-settings > div {
+    position: static;
+    width: min(100%, 19rem);
+    margin-top: 0.45rem;
+  }
+
+  .mi-run-settings .form-check {
+    grid-column: auto;
   }
 
   .mi-scan-actions .btn {
@@ -1134,6 +1507,23 @@ a:hover {
     min-height: 44px;
   }
 
+  .mi-memory-heading {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .mi-memory-badge {
+    grid-column: 1 / -1;
+    width: max-content;
+  }
+
+  .mi-memory-effect > p {
+    margin-left: 0;
+  }
+
+  .mi-review-consequences > div {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .mi-ledger-entry {
     grid-template-columns: 1.25rem minmax(0, 1fr);
   }
@@ -1141,6 +1531,12 @@ a:hover {
   .mi-reset {
     align-items: stretch;
     flex-direction: column;
+  }
+}
+
+@media (max-width: 359.98px) {
+  .mi-review-actions {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/man/kg_tools.Rd
+++ b/man/kg_tools.Rd
@@ -18,6 +18,7 @@ one initialized store. The tools expose only graft's bounded retrieval
 functions; they do not accept SQL, file paths, URLs, or network options.
 }
 \details{
-Every tool returns the native graft result in \code{result} plus explicit
-\code{truncated}, \code{limit}, and \code{store_schema_digest} fields.
+Every tool returns a JSON-compatible representation of the graft result in
+\code{result} plus explicit \code{truncated}, \code{limit}, and \code{store_schema_digest}
+fields.
 }

--- a/tests/testthat/_snaps/market-intelligence-example.md
+++ b/tests/testthat/_snaps/market-intelligence-example.md
@@ -1,0 +1,8 @@
+# market planner requires an ISO action due date
+
+    Code
+      environment$mi_run_planner(environment$mi_reference_planner(bundle), bundle$
+        suggested_request, bundle, "No accepted market assessments yet.")
+    Condition
+      Error in `mi_iso_date()`:
+      ! `planner$due_date` must be a valid ISO date (YYYY-MM-DD).

--- a/tests/testthat/test-agent-tools.R
+++ b/tests/testthat/test-agent-tools.R
@@ -273,13 +273,24 @@ test_that("ToolDefs invoke directly and return universal metadata", {
     expect_identical(output$store_schema_digest, digest)
     expect_identical(is.null(output$limit), FALSE)
   }
-  expect_s3_class(outputs$kg_describe$result, "kg_context")
-  expect_s3_class(outputs$kg_open_knowledge$result, "kg_okf_context")
+  expect_type(outputs$kg_describe$result, "list")
+  expect_type(outputs$kg_open_knowledge$result, "list")
   expect_s3_class(outputs$kg_find$result, "data.frame")
-  expect_s3_class(outputs$kg_get$result, "kg_record")
-  expect_s3_class(outputs$kg_neighbors$result, "kg_subgraph")
+  expect_type(outputs$kg_get$result, "list")
+  expect_type(outputs$kg_neighbors$result, "list")
   expect_s3_class(outputs$kg_claims$result, "data.frame")
   expect_s3_class(outputs$kg_select$result, "data.frame")
+
+  serialized <- vapply(
+    outputs,
+    \(output) as.character(jsonlite::toJSON(output, auto_unbox = TRUE)),
+    character(1)
+  )
+  expect_named(serialized, names(outputs))
+  expect_identical(
+    vapply(serialized, nzchar, logical(1)),
+    stats::setNames(rep(TRUE, length(outputs)), names(outputs))
+  )
 
   expect_identical(outputs$kg_describe$limit, 40L)
   expect_identical(

--- a/tests/testthat/test-market-intelligence-example.R
+++ b/tests/testthat/test-market-intelligence-example.R
@@ -307,6 +307,7 @@ test_that("market intelligence UI exposes the complete decision loop", {
   if (!market_intelligence_runtime_available()) {
     testthat::skip("The current market-intelligence runtime is unavailable.")
   }
+  withr::local_options(sass.cache = withr::local_tempdir())
   environment <- local_market_intelligence_environment(include_app = TRUE)
   ui <- as.character(environment$mi_app_ui())
   baseline <- environment$mi_read_json(
@@ -338,6 +339,51 @@ test_that("market intelligence UI exposes the complete decision loop", {
   )
 })
 
+test_that("market intelligence UI makes the daily decision legible", {
+  if (!market_intelligence_runtime_available()) {
+    testthat::skip("The current market-intelligence runtime is unavailable.")
+  }
+  environment <- local_market_intelligence_environment(include_app = TRUE)
+  worker <- local_market_intelligence_worker(environment)
+  snapshot <- environment$mi_worker_prepare(worker)
+  briefing <- as.character(environment$mi_app_briefing_view(
+    snapshot,
+    environment$mi_worker_progress(worker),
+    3L
+  ))
+  review <- as.character(environment$mi_app_review_view(snapshot))
+
+  expect_identical(snapshot$scan_date, "2026-07-23")
+  expect_match(briefing, "Your daily market brief")
+  expect_match(briefing, "July 23, 2026")
+  expect_match(briefing, "What changed")
+  expect_match(briefing, "Why it matters")
+  expect_match(briefing, "What accepted memory changed")
+  expect_match(briefing, "Proposed next step")
+  expect_match(briefing, 'id="open_review"', fixed = TRUE)
+  expect_match(review, "Observed")
+  expect_match(review, "Interpreted")
+  expect_match(review, "Proposed")
+  expect_match(review, "What your decision does")
+  expect_match(review, "Approve and save to Graft")
+  expect_match(review, "Accepted Graft memory remains unchanged")
+
+  environment$mi_worker_resolve(worker, "approved")
+  second_snapshot <- environment$mi_worker_prepare(worker)
+  second_briefing <- as.character(environment$mi_app_briefing_view(
+    second_snapshot,
+    environment$mi_worker_progress(worker),
+    3L
+  ))
+
+  expect_identical(second_snapshot$scan_date, "2026-07-24")
+  expect_match(second_briefing, "Accepted memory applied")
+  expect_match(
+    second_briefing,
+    "Accepted Graft history informed this brief"
+  )
+})
+
 test_that("market intelligence UI escapes model-supplied markdown", {
   if (!market_intelligence_runtime_available()) {
     testthat::skip("The current market-intelligence runtime is unavailable.")
@@ -357,8 +403,15 @@ test_that("market intelligence UI escapes model-supplied markdown", {
       headline = "Signal",
       summary = "Summary",
       implication = "Implication",
-      continuity = "Continuity"
-    )
+      continuity = "Continuity",
+      memory_used = FALSE,
+      action = list(
+        title = "Review the signal",
+        owner = "Market strategy",
+        due_date = "2026-08-07"
+      )
+    ),
+    pending = list()
   )))
 
   expect_match(escaped, "&lt;script&gt;", fixed = TRUE)

--- a/tests/testthat/test-market-intelligence-example.R
+++ b/tests/testthat/test-market-intelligence-example.R
@@ -101,6 +101,30 @@ test_that("market planner visibly uses accepted memory", {
   expect_match(result$briefing_markdown, "## Continuity")
 })
 
+test_that("market planner requires an ISO action due date", {
+  if (!market_intelligence_runtime_available()) {
+    testthat::skip("The current market-intelligence runtime is unavailable.")
+  }
+  environment <- local_market_intelligence_environment()
+  bundle <- environment$mi_read_json(
+    market_intelligence_example_path(
+      "corpus",
+      "2026-07-23-quarterly-results.json"
+    )
+  )
+  bundle$proposal$due_date <- "Within 10 business days"
+
+  expect_snapshot(
+    environment$mi_run_planner(
+      environment$mi_reference_planner(bundle),
+      bundle$suggested_request,
+      bundle,
+      "No accepted market assessments yet."
+    ),
+    error = TRUE
+  )
+})
+
 test_that("market worker keeps assessment outside Graft until approval", {
   if (!market_intelligence_runtime_available()) {
     testthat::skip("The current market-intelligence runtime is unavailable.")

--- a/tests/testthat/test-okf.R
+++ b/tests/testthat/test-okf.R
@@ -60,6 +60,19 @@ test_that("kg_export_okf writes a deterministic source-linked bundle", {
   )
   frontmatter <- graft:::okf_parse_frontmatter(claim_path)
   body <- paste(readLines(claim_path, warn = FALSE), collapse = "\n")
+  entity_path <- file.path(
+    first_path,
+    "concepts",
+    "Entity",
+    paste0(
+      utils::URLencode(fixture$ids$lldpe, reserved = TRUE),
+      ".md"
+    )
+  )
+  entity_body <- paste(
+    readLines(entity_path, warn = FALSE),
+    collapse = "\n"
+  )
 
   expect_identical(frontmatter$type, "Claim")
   expect_identical(frontmatter$status, "stable")
@@ -81,6 +94,7 @@ test_that("kg_export_okf writes a deterministic source-linked bundle", {
   expect_match(body, "## Relationships", fixed = TRUE)
   expect_match(body, "/concepts/Entity/", fixed = TRUE)
   expect_match(body, "[^source-", fixed = TRUE)
+  expect_length(grep("[^]", entity_body, fixed = TRUE), 0L)
 })
 
 test_that("kg_export_okf recovers a historical accepted boundary", {

--- a/vignettes/market-intelligence.Rmd
+++ b/vignettes/market-intelligence.Rmd
@@ -85,13 +85,18 @@ radar <- system.file(
 shiny::runApp(file.path(radar, "app"))
 ```
 
-The five views expose separate parts of the contract:
+The five views expose separate parts of the contract. The primary path stays
+deliberately quiet: read the daily brief, inspect what accepted memory changed,
+and open the decision room only when a proposal needs judgment.
 
-- **Briefing** shows the current evidence packet and source-linked narrative.
+- **Briefing** separates what changed, why it matters, the effect of accepted
+  memory, and one proposed next step. Materiality, confidence, and evidence
+  counts remain visible without competing with the narrative.
 - **Portfolio map** shows enterprise overlap, business-specific competitors,
   and downstream lenses.
-- **Review** shows the exact assessment and accountable action proposed for
-  durable storage.
+- **Review** presents observed evidence, analyst interpretation, and proposed
+  action as distinct layers. It states the Graft consequence of approval or
+  rejection before the user decides.
 - **Knowledge** contains only approved assessments and open actions.
 - **Audit** separates Tempest workflow events from accepted Graft runs.
 


### PR DESCRIPTION
## Summary

- Return JSON-compatible envelopes from all seven `kg_tools()` definitions so ellmer providers can complete live tool-call loops while retaining truncation, limit, and schema-digest metadata.
- Require valid ISO `YYYY-MM-DD` action due dates in the market-intelligence planner before approved records reach DuckDB.
- Avoid empty OKF citation markers on source-free summaries and ignore local dsprrr cache artifacts.

## Verification

- `devtools::test()` against the development Tempest checkout: 1,392 passed with no failures, warnings, or skips.
- `pkgdown::check_pkgdown()`: no problems.
- `devtools::check()`: 0 errors, 0 warnings, 0 notes.
- A live two-day rehearsal through tidyverse/ellmer#1067 and ChatGPT subscription authentication approved Day 1, synchronized 24 OKF concepts with zero Tempest diagnostics, used accepted memory on Day 2, preserved accepted state after rejection, and completed an actual `kg_open_knowledge` request/result round trip.
