### PR TITLE
Refresh the knowledge site and shorten PR checks

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,6 +13,10 @@ name: R-CMD-check.yaml
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -30,6 +34,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      TESTTHAT_CPUS: 4
 
     steps:
       - uses: actions/checkout@v6
@@ -49,4 +54,3 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
-

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -21,9 +21,11 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -37,8 +39,35 @@ jobs:
       - name: Build site
         run: Rscript tools/build-pkgdown.R
 
-      - name: Deploy to GitHub pages 🚀
+      - name: Upload site
         if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkgdown-site
+          path: docs
+          include-hidden-files: true
+          if-no-files-found: error
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: pkgdown
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pkgdown-deploy
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: pkgdown-site
+          path: docs
+
+      - name: Deploy to GitHub pages 🚀
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           clean: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,17 +3,22 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
+  workflow_dispatch:
 
 name: test-coverage.yaml
 
 permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      TESTTHAT_PARALLEL: 'false'
     permissions:
       contents: read
       id-token: write

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,9 @@ Suggests:
     testthat (>= 3.0.0),
     withr
 Config/testthat/edition: 3
+Config/testthat/parallel: true
+Config/testthat/start-first: measure-eval, snapshot, commit-plan, agent-tools,
+    reuse-basis, changes
 Config/roxygen2/version: 8.0.0
 Config/Needs/check: posit-dev/commons/pkg-r, JamesHWade/dsprrr, JamesHWade/deputy
 Config/Needs/coverage: posit-dev/commons/pkg-r, JamesHWade/dsprrr, JamesHWade/deputy

--- a/README.md
+++ b/README.md
@@ -5,22 +5,20 @@
 [![Codecov test coverage](https://codecov.io/gh/JamesHWade/graft/graph/badge.svg)](https://app.codecov.io/gh/JamesHWade/graft)
 <!-- badges: end -->
 
-R workflows often produce several related tables. When each run replaces the
-last one, it becomes difficult to recover an earlier value, trace a correction
-to its source, or review a relationship before it is used downstream.
+graft gives R workflows and agents durable, reviewed knowledge. Preserve research
+conclusions, interpretations, definitions and related records so a later task
+can reuse an exact accepted version and inspect what changed.
 
-graft turns those tables into reviewed, versioned knowledge. Start with a
-[data-dict](https://data-dict.tidyverse.org/) contract, create a new local
-store, inspect each proposed change before writing it, and retrieve current
-records alongside their accepted history. LinkML is available when the domain
-needs richer graph semantics.
+Start with a [data-dict](https://data-dict.tidyverse.org/) contract. Graft adds
+validated acceptance, stable identity, revision history, snapshots and bounded
+reads. Applications own the meaning of accepted content, permission to consult
+it and authority to execute code. Acceptance is not factual truth.
 
-That accepted knowledge is also meant to be read by agents. `graft_tools()`
-turns a store, or a pinned snapshot of one, into bounded read-only
-[ellmer](https://ellmer.tidyverse.org/) tools — no SQL, no connection, no write
-path — and an agent that proposes records goes through the same validation,
-provenance, and review as any other producer. See [Work with
-agents](https://jameshwade.github.io/graft/articles/agents.html).
+Follow the [offline quickstart](https://jameshwade.github.io/graft/articles/getting-started.html),
+try [narrative reuse](https://jameshwade.github.io/graft/articles/ecosystem.html),
+or retain an [exact reuse basis](https://jameshwade.github.io/graft/articles/reuse-basis.html).
+The tested agent recipes use ellmer, Deputy and dsprrr. Commons receives a
+detached public source; LinkML supports richer graph domains.
 
 ## Installation
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,17 +24,16 @@ template:
     navbar-dark-bg: "#12362D"
 
 home:
-  title: "graft: Connected knowledge from R tables"
+  title: "graft: Durable knowledge for R workflows and agents"
   description: >
-    Start with related R tables and a data-dict contract, create a new local
-    store, review changes before writing, keep current records with their
-    accepted history, and give agents bounded read-only access to it.
+    Review and retain research conclusions, interpretations and related records
+    with data-dict contracts, accepted history and exact reuse for later tasks.
   sidebar:
     structure: [links, license, authors, dev]
 
 navbar:
   structure:
-    left: [intro, learn, design, reference, news]
+    left: [intro, learn, integrate, design, reference, news]
     right: [search, github, lightswitch]
   components:
     intro:
@@ -49,21 +48,26 @@ navbar:
           href: articles/knowledge-change-control.html
         - text: Retrieve records and history
           href: articles/retrieval.html
+        - text: Retain an exact reuse basis
+          href: articles/reuse-basis.html
+        - text: Calculate with accepted Definitions
+          href: reference/graft_calculate.html
+    integrate:
+      text: Integrate
+      menu:
         - text: Work with agents
           href: articles/agents.html
         - text: Reuse narrative knowledge
           href: articles/ecosystem.html
-        - text: Retain an exact reuse basis
-          href: articles/reuse-basis.html
         - text: Supported integrations
           href: articles/compatibility.html
+    design:
+      text: Design
+      menu:
         - text: Add graph semantics with LinkML
           href: articles/linkml-schema.html
         - text: Open knowledge
           href: articles/open-knowledge-format.html
-    design:
-      text: Design
-      menu:
         - text: Architecture
           href: articles/architecture.html
         - text: Contract compilers

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -313,7 +313,7 @@ footer {
   display: flow-root;
 }
 
-.graft-hero h2, h1, h2, h3 {
+h1, h2, h3 {
   hyphens: none;
 }
 

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -105,8 +105,9 @@ samp {
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  margin: 0.5rem 0 3.5rem;
-  padding: clamp(2rem, 6vw, 4.75rem);
+  clear: both;
+  margin: 0.5rem 0 2rem;
+  padding: clamp(1.5rem, 4vw, 2.75rem);
   border: 1px solid var(--graft-border);
   border-radius: 1.35rem;
   background:
@@ -164,12 +165,12 @@ samp {
 }
 
 .graft-hero h2 {
-  max-width: 18ch;
+  max-width: 24ch;
   margin-bottom: 1.1rem;
   color: var(--graft-forest-deep);
-  font-size: clamp(2.2rem, 6vw, 4.4rem);
+  font-size: clamp(2rem, 4vw, 3.3rem);
   letter-spacing: -0.045em;
-  line-height: 0.98;
+  line-height: 1.08;
 }
 
 [data-bs-theme="dark"] .graft-hero h2 {
@@ -306,4 +307,53 @@ footer {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
   }
+}
+
+.page-header {
+  display: flow-root;
+}
+
+.graft-hero h2, h1, h2, h3 {
+  hyphens: none;
+}
+
+.graft-paths {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+}
+
+.graft-paths section {
+  padding: 1.25rem;
+  background: var(--graft-surface-soft);
+  border: 1px solid var(--graft-border);
+  border-radius: 0.75rem;
+}
+
+.graft-paths h3 {
+  margin-top: 0;
+  font-size: 1.3rem;
+}
+
+.graft-paths p:last-child {
+  margin-bottom: 0;
+}
+
+:focus-visible {
+  outline: 3px solid var(--bs-link-color);
+  outline-offset: 3px;
+}
+
+@media (max-width: 575.98px) {
+  .page-header .logo {
+    width: 72px;
+    max-width: 72px;
+    height: auto;
+    margin-left: 0.75rem;
+  }
+  .graft-paths { grid-template-columns: 1fr; }
+  .graft-hero { padding: 1.25rem; }
+  .graft-eyebrow { letter-spacing: 0.07em; }
+  .graft-workflow th, .graft-workflow td { padding: 0.4rem; }
 }

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -1,239 +1,111 @@
 # graft
 
 <div class="graft-hero">
-<p class="graft-eyebrow">Knowledge from ordinary R tables</p>
-<h2 data-toc-skip>Turn related tables into knowledge you can update without losing history.</h2>
+<p class="graft-eyebrow">Durable knowledge for R workflows and agents</p>
+<h2 data-toc-skip>Keep what you learn.<br>Review what changes.</h2>
 <p class="graft-hero-copy">
-Start with data frames and a data-dict contract. graft creates a new local
-store, checks related records before it writes, records where each accepted
-change came from, and keeps earlier versions available &mdash; then hands that
-accepted knowledge to an agent as bounded, read-only tools.
+Give research conclusions, interpretations, definitions and related records an
+accepted history. Start with <code>data-dict.yaml</code>, review proposed changes,
+and let a later task return to the exact knowledge an earlier task used.
 </p>
 <div class="graft-actions">
 <a class="btn btn-primary" href="articles/getting-started.html">Build your first store</a>
-<a class="btn btn-outline-secondary" href="articles/agents.html">Work with agents</a>
+<a class="btn btn-outline-secondary" href="articles/ecosystem.html">Try narrative reuse</a>
 </div>
 </div>
 
-## Start with the data you already have
+## From a result to a reusable record
 
-Suppose an R workflow produces three tables:
+An R workflow produces a conclusion. A person corrects it. A later agent needs
+the earlier answer and the evidence behind it. Replacing yesterday's file
+loses that distinction; Graft retains each accepted revision and the producer
+recorded for the change.
 
-| Table | What one row represents | Important fields |
-|---|---|---|
-| `organization` | An organization | `id`, `name` |
-| `person` | A person | `id`, `full_name`, `job_title` |
-| `employment` | A person's employment | `person_id`, `organization_id` |
+<table class="table graft-workflow">
+<thead><tr><th>Describe</th><th>Review</th><th>Reuse</th></tr></thead>
+<tbody><tr>
+<td>Use data-dict to describe fields, meaning and relationships.</td>
+<td>Inspect a proposed plan, correct invalid references, then accept it.</td>
+<td>Read current history or pin an exact boundary for a later task.</td>
+</tr></tbody>
+</table>
 
-Those tables can answer who works where today. They do not, by themselves,
-tell you whether an employment row points to a known organization, who supplied
-a correction, what a reviewer accepted, or what the previous job title was.
+data-dict supplies the contract. Graft adds validated acceptance, stable
+identity, revisions, snapshots and bounded retrieval. Ordinary tables are a
+useful starting point; their values can include Markdown, interpretations,
+preferences and normalized evidence links.
 
-graft adds stable record identity, relationship checks, source provenance, a
-review step, and revision history. These are the foundations of useful
-knowledge: facts that remain connected and explainable as they change. They are
-also what makes accepted knowledge safe to put in front of a model.
+Acceptance records a decision for a purpose. It does not make a claim true,
+authorize access, or permit execution of stored code. Applications retain those
+responsibilities.
 
-## Install graft
+## Start in R
 
-graft is currently installed from GitHub:
+Install the development package:
 
 ```r
 pak::pak("JamesHWade/graft")
 ```
 
-Using a resolved data-dict contract and an existing `.graft.json` contract is
-R-only. The data-dict CLI is needed only to resolve authored YAML, and Python
-with `linkml-runtime` is needed only to compile LinkML source.
+The [quickstart](articles/getting-started.html) runs entirely offline. It uses a
+shipped resolved data-dict contract to create a store, reject a broken
+reference, accept a correction, inspect history and pin a snapshot. No model
+credentials or Python installation are required.
 
-## Describe the tables with a contract
+Author your own `data-dict.yaml` with the optional data-dict CLI, then compile
+its resolved export in R. Existing compiled contracts also run in R alone.
+[LinkML](articles/linkml-schema.html) remains available for domains needing
+richer graph semantics.
 
-[data-dict](https://data-dict.tidyverse.org/) gives the tables and their
-relationships a readable contract. The package includes this example as
-`team-directory.data-dict.yaml`; an abridged excerpt of its relationships is:
+## Choose your next workflow
 
-```yaml
-tables:
-  - name: person
-  - name: organization
-  - name: employment
+<div class="graft-paths">
+<section>
+<h3>Review changing knowledge</h3>
+<p>Keep proposals separate from accepted records. Inspect changes, handle stale
+plans and retry without manufacturing another revision.</p>
+<p><a href="articles/knowledge-change-control.html">Review and accept changes</a></p>
+</section>
+<section>
+<h3>Return to an exact answer</h3>
+<p>Retain the full selected evidence across restarts and unchanged days. Flag
+changed dependencies for review while preserving the earlier interpretation.</p>
+<p><a href="articles/reuse-basis.html">Retain an exact reuse basis</a></p>
+</section>
+<section>
+<h3>Give an agent bounded reads</h3>
+<p>Use ordinary ellmer tools with ellmer, Deputy or dsprrr. Keep connections in
+the process that owns them and reconnect workers from serializable references.</p>
+<p><a href="articles/ecosystem.html">Explore tested host recipes</a></p>
+</section>
+<section>
+<h3>Calculate and inspect receipts</h3>
+<p>Evaluate accepted Definitions against a pinned boundary. Inspect the recorded
+evidence path without treating a receipt as a fact-check.</p>
+<p><a href="reference/graft_calculate.html">Calculate with accepted Definitions</a></p>
+</section>
+</div>
 
-relationships:
-  - join: employment.person_id = person.id
-  - join: employment.organization_id = organization.id
-```
+## What works together today
 
-The data-dict CLI resolves authoring YAML with `export-spec` once. graft
-compiles the resolved JSON using R alone, then creates the store — no existing
-database required:
+Graft's tested host loops cover ellmer, Deputy and dsprrr; Commons consumes a
+detached public copy and retains its own file measures. Tempest owns research
+products and promotion, with accepted-evidence restart checks. Rill's Reader
+integration, isolation and permanent Forget gates remain separate work.
 
-```r
-library(graft)
+The [integration guide](articles/compatibility.html) records supported versions
+and limitations. The [ecosystem guide](articles/ecosystem.html) separates tested
+composition from planned application behavior. Generic read tools alone do not
+enforce Reader permissions or decide what an agent may consult automatically.
 
-schema <- graft_schema(system.file(
-  "extdata",
-  "team-directory.data-dict.json",
-  package = "graft",
-  mustWork = TRUE
-))
+## Read a result's evidence path
 
-store <- graft_open(schema, tempfile(fileext = ".duckdb"), okf = "disabled")
-```
+Graft classifies recorded answer evidence as **Verified**, **Cited** or
+**Untrusted**. Verified paths use governed calculations with matching receipts;
+Cited paths use independently matched Graft reads. Failures, unknown sources or
+mixed unsupported evidence keep a result Untrusted.
 
-## Review each change before it is written
-
-Candidate records are ordinary data frames. This batch has a valid person and
-organization, but its employment row points to an organization that does not
-exist:
-
-```r
-records <- list(
-  organization = data.frame(
-    id = "org:daily-planet",
-    name = "Daily Planet"
-  ),
-  person = data.frame(
-    id = "person:lois-lane",
-    full_name = "Lois Lane",
-    job_title = "Reporter"
-  ),
-  employment = data.frame(
-    id = "employment:lois-lane:daily-planet",
-    person_id = "person:lois-lane",
-    organization_id = "org:missing"
-  )
-)
-
-origin <- graft_provenance(
-  producer = "directory-import",
-  idempotency_key = "directory-2026-08-09"
-)
-
-plan <- graft_plan(store, records, origin)
-plan@valid
-#> [1] FALSE
-
-plan@issues[, c("class", "record_id", "field", "message")]
-#>        class                         record_id           field                                        message
-#> 1 employment employment:lois-lane:daily-planet organization_id Reference target `org:missing` does not exist.
-```
-
-Planning writes nothing, so a rejected batch can be corrected and reviewed
-again. `graft_commit()` rechecks the reviewed plan and accepts all three
-records in one transaction, or none of them:
-
-```r
-records$employment$organization_id <- "org:daily-planet"
-plan <- graft_plan(store, records, origin)
-
-plan@changes[, c("class", "record_id", "action")]
-#>          class                         record_id action
-#> 1 organization                  org:daily-planet insert
-#> 2       person                  person:lois-lane insert
-#> 3   employment employment:lois-lane:daily-planet insert
-
-graft_commit(store, plan)
-```
-
-## Keep the old version when a fact changes
-
-A later review changes Lois's role. The update is another reviewable plan, not
-an overwrite:
-
-```r
-update_plan <- graft_plan(
-  store,
-  list(person = data.frame(
-    id = "person:lois-lane",
-    full_name = "Lois Lane",
-    job_title = "Investigative editor"
-  )),
-  graft_provenance(
-    producer = "hr-review",
-    idempotency_key = "hr-review-2026-08-10"
-  )
-)
-
-update_plan@changes[, c("record_id", "action", "changed_fields")]
-#>          record_id action changed_fields
-#> 1 person:lois-lane update      job_title
-
-graft_commit(store, update_plan)
-
-graft_history(store, "person:lois-lane")[
-  , c("revision_number", "producer", "changed_fields")
-]
-#>   revision_number         producer changed_fields
-#> 1               2        hr-review      job_title
-#> 2               1 directory-import   full_nam....
-```
-
-Current retrieval returns the new title. History retains both accepted
-versions and the producer behind each change.
-
-## Give an agent bounded reads
-
-An agent is only as trustworthy as the knowledge it reads. graft gives a model
-records that were validated on the way in, attributed to a producer, and pinned
-so they cannot move mid-session.
-
-`graft_snapshot()` captures the accepted boundary as a serializable, path-free
-value, `graft_at()` binds it to a read-only view, and `graft_tools()` turns that
-view into bounded [ellmer](https://ellmer.tidyverse.org/) tools:
-
-```r
-snapshot <- graft_snapshot(store)
-view <- graft_at(store, snapshot)
-
-tools <- graft_tools(view)
-names(tools)
-#> [1] "graft_find"       "graft_get"        "graft_query"
-#> [4] "graft_history"    "graft_dictionary"
-
-chat <- ellmer::chat_anthropic()
-chat$set_tools(tools)
-chat$chat("Who works at the Daily Planet, and has that person's title changed?")
-
-graft_close(store)
-```
-
-The tools search, retrieve, run bounded advanced operations, and read revision
-history. They accept no SQL, connection, path, or write argument, and every
-result reports the limit it applied, whether it was truncated, and the digest of
-the contract it came from. Fields the contract marks restricted never reach
-them.
-
-Writes stay on the reviewed path. An agent that proposes records becomes a
-named producer whose plan is validated and inspected like any other, and a
-file-editing agent works through a readable Open Knowledge Format tree whose
-edits remain proposals until they are reviewed. [Work with
-agents](articles/agents.html) covers all three.
-
-## Choose a contract provider
-
-data-dict is the simpler starting point when the domain is naturally tabular.
-Its foreign keys let graft reject missing targets, but they are not graph
-traversal edges. Move to [LinkML](articles/linkml-schema.html) when you need
-relationships that support graph traversal, inheritance, ontology identifiers,
-or polymorphic references.
-
-Both providers compile to the same Graft contract and use the same plan,
-commit, retrieval, and history functions. The provider changes how the domain
-is described; it does not create another way to write accepted knowledge.
-
-## Continue learning
-
-- [Get started](articles/getting-started.html) works through this example with
-  its results, then hands the store to an agent.
-- [Use a data-dict contract](articles/data-dict-schema.html) covers table-first
-  authoring, compilation, and what the table profile enforces.
-- [Review knowledge changes](articles/knowledge-change-control.html) explains
-  plans, commit preconditions, and retries.
-- [Retrieve current records and history](articles/retrieval.html) maps each read
-  function to its job.
-- [Work with agents](articles/agents.html) covers bounded tools, pinned
-  snapshots, agent-authored proposals, and file-editing agents.
-- [Add graph semantics with LinkML](articles/linkml-schema.html) continues from
-  governed tables to typed traversal relationships.
-- [Understand the architecture](articles/architecture.html) explains storage,
-  projections, and selective use of S7.
+These labels describe the recorded path. They do not measure factual accuracy,
+authenticate producer identities or guarantee that prose faithfully represents
+a source. [Work with agents](articles/agents.html) explains the checks and their
+limits.

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -90,7 +90,8 @@ evidence path without treating a receipt as a fact-check.</p>
 
 Graft's tested host loops cover ellmer, Deputy and dsprrr; Commons consumes a
 detached public copy and retains its own file measures. Tempest owns research
-products and promotion, with accepted-evidence restart checks. Rill's Reader
+products and promotion; accepted-evidence restart integration is tracked in
+[#50](https://github.com/JamesHWade/graft/issues/50). Rill's Reader
 integration, isolation and permanent Forget gates remain separate work.
 
 The [integration guide](articles/compatibility.html) records supported versions

--- a/tests/testthat/helper-schema.R
+++ b/tests/testthat/helper-schema.R
@@ -126,9 +126,12 @@ materialize_test_schema_import <- function(path) {
   if (!any(grepl("graft-core.linkml", source, fixed = TRUE))) {
     return(path)
   }
-  source <- stage_test_schema_core(source, dirname(path))
-  writeLines(source, path)
-  path
+  directory <- tempfile("graft-test-schema-")
+  dir.create(directory)
+  source <- stage_test_schema_core(source, directory)
+  staged_path <- file.path(directory, basename(path))
+  writeLines(source, staged_path)
+  staged_path
 }
 
 stage_test_schema_core <- function(source, directory) {

--- a/tests/testthat/helper-schema.R
+++ b/tests/testthat/helper-schema.R
@@ -126,8 +126,11 @@ materialize_test_schema_import <- function(path) {
   if (!any(grepl("graft-core.linkml", source, fixed = TRUE))) {
     return(path)
   }
-  directory <- tempfile("graft-test-schema-")
-  dir.create(directory)
+  directory <- file.path(
+    tempfile("graft-test-schema-"),
+    basename(dirname(path))
+  )
+  dir.create(directory, recursive = TRUE)
   source <- stage_test_schema_core(source, directory)
   staged_path <- file.path(directory, basename(path))
   writeLines(source, staged_path)
@@ -168,6 +171,12 @@ skip_if_no_linkml_runtime <- function() {
 }
 
 redact_repo_path <- function(x) {
+  x <- gsub(
+    "(^|`)[^`\n]+/graft-test-schema-[^/]+/",
+    "\\1<repo>/tests/testthat/fixtures/",
+    x,
+    perl = TRUE
+  )
   redacted <- gsub(
     normalizePath(test_path("..", ".."), winslash = "/"),
     "<repo>",

--- a/tests/testthat/test-schema-compile.R
+++ b/tests/testthat/test-schema-compile.R
@@ -142,6 +142,12 @@ test_that("snapshot paths are stable in covr's installed test layout", {
       "invalid-qualifier.linkml.yaml"
     )
   )
+  expect_identical(
+    redact_repo_path(
+      "Error in `/tmp/worker/graft-test-schema-123/invalid-records/example.yaml`"
+    ),
+    "Error in `<repo>/tests/testthat/fixtures/invalid-records/example.yaml`"
+  )
 })
 
 test_that("installed core imports are staged beside test schemas", {

--- a/tools/build-pkgdown.R
+++ b/tools/build-pkgdown.R
@@ -83,15 +83,15 @@ if (
   )
 }
 
-forbidden_outputs <- file.path(
+forbidden_outputs <- list.files(
   destination_dir,
-  c("AGENTS.html", "AGENTS.md", "CONTEXT.html", "CONTEXT.md")
+  pattern = "^(AGENTS|CONTEXT)[.](html|md)$",
+  recursive = TRUE
 )
-forbidden_outputs <- forbidden_outputs[file.exists(forbidden_outputs)]
 if (length(forbidden_outputs) > 0L) {
   stop(
     "The site contains forbidden instruction artifacts: ",
-    paste(basename(forbidden_outputs), collapse = ", "),
+    paste(forbidden_outputs, collapse = ", "),
     call. = FALSE
   )
 }

--- a/tools/build-pkgdown.R
+++ b/tools/build-pkgdown.R
@@ -34,7 +34,7 @@ staged_source <- tempfile("graft-pkgdown-source-")
 dir.create(staged_source)
 on.exit(unlink(staged_source, recursive = TRUE, force = TRUE), add = TRUE)
 
-excluded_entries <- c(".git", "AGENTS.md", "docs")
+excluded_entries <- c(".git", "AGENTS.md", "CONTEXT.md", "docs")
 source_entries <- list.files(
   source_dir,
   all.files = TRUE,
@@ -83,7 +83,10 @@ if (
   )
 }
 
-forbidden_outputs <- file.path(destination_dir, c("AGENTS.html", "AGENTS.md"))
+forbidden_outputs <- file.path(
+  destination_dir,
+  c("AGENTS.html", "AGENTS.md", "CONTEXT.html", "CONTEXT.md")
+)
 forbidden_outputs <- forbidden_outputs[file.exists(forbidden_outputs)]
 if (length(forbidden_outputs) > 0L) {
   stop(
@@ -100,14 +103,14 @@ indexable_files <- list.files(
   full.names = TRUE,
   ignore.case = TRUE
 )
-# Match the instruction file by its exact uppercase name. A case-insensitive
+# Match the internal files by their exact uppercase names. A case-insensitive
 # pattern would also match the lowercase `agents` article, which is ordinary
 # site content.
 mentions_instructions <- vapply(
   indexable_files,
   \(path) {
     content <- readLines(path, warn = FALSE, encoding = "UTF-8")
-    any(grepl("\\bAGENTS[.](md|html)\\b", content))
+    any(grepl("\\b(AGENTS|CONTEXT)[.](md|html)\\b", content))
   },
   logical(1)
 )
@@ -118,12 +121,12 @@ if (any(mentions_instructions)) {
     nchar(destination_dir) + 2L
   )
   stop(
-    "The site still refers to AGENTS.md: ",
+    "The site still refers to an internal instruction file: ",
     paste(offenders, collapse = ", "),
     call. = FALSE
   )
 }
 
 message(
-  "Verified that AGENTS.md is absent from the published site and indexes."
+  "Verified that AGENTS.md and CONTEXT.md are absent from the site and indexes."
 )

--- a/tools/site-refresh-review.md
+++ b/tools/site-refresh-review.md
@@ -1,0 +1,46 @@
+# Site refresh review
+
+Baseline built from merged Graft 2de56e6. Reviewed homepage, quickstart,
+ecosystem guide and tool reference in the in-app browser.
+
+- At 320px, the floated 139px logo squeezed the homepage hero to a narrow
+  column, splitting almost every heading word. Clear the hero and reduce the
+  small-screen logo; retain the existing frog artwork.
+- At desktop size, the long hero heading pushed both actions below the first
+  screen. Shorten the outcome statement and reduce its type and padding.
+- The homepage duplicated most of the quickstart, including manually maintained
+  results. Move the tutorial to its existing URL and expose task-based routes.
+- “Safe to put in front of a model” and broad trust claims exceeded validation
+  and receipt guarantees. Explain acceptance, exact reuse and verification limits.
+- The Learn menu mixed authoring, retrieval, hosting and representation design.
+  Give integrations a separate menu and preserve existing article URLs.
+
+## Validation
+
+Reviewed the homepage, getting-started guide, ecosystem guide and
+`graft_tools()` reference at 320, 768 and 1280 pixels in light and dark modes.
+Screenshots were inspected in the task conversation. All four pages stayed
+within the viewport at every size; long headings wrapped without splitting
+words. The 72px mobile logo no longer squeezes the hero. Code blocks and the
+wide integration table scroll within their own bounds.
+
+The native mobile menu and theme switch work. Keyboard search for “reuse” finds
+the exact-basis guide; Arrow Down changes selection and Enter opens the selected
+published URL. Tab navigation shows a 3px focus outline with a 3px offset.
+Text, links and buttons remain legible in both themes. The decorative logo has
+empty alt text beside the package heading. The existing reduced-motion rule
+removes transitions and hover transforms; no new animation was introduced.
+
+Search also exposed `CONTEXT.md` as an unintended user guide. The existing
+staged build now excludes it alongside `AGENTS.md` and checks generated pages,
+search, sitemap and LLM indexes for either internal filename. The final search
+no longer includes the glossary.
+
+`tools/build-pkgdown.R` completed successfully, including installed-package
+examples, all offline articles, reference/link checks and the internal-file
+exclusion check. The GitHub workflow still builds PRs without deployment and
+publishes `docs/` to `gh-pages` on its existing non-PR triggers. Search navigation
+confirmed that the existing published reuse-guide URL remains valid.
+
+This is a local implementation review. PR CI and verification of the refreshed
+published site remain required after publication and an authorized merge.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -25,10 +25,14 @@ relationship before writing anything, accepts corrected records, preserves a
 later update as a second revision, and then hands that accepted knowledge to an
 agent as read-only tools.
 
-That last step is the point of the earlier ones. An agent is only as
-trustworthy as the knowledge it reads: validated on the way in, attributed to a
-producer, and stable while the agent is reasoning about it. Graft is built to
-give a model exactly that, and nothing more.
+A pinned view lets a later task read the same accepted versions even after a
+correction. Validation checks the declared contract; it does not establish
+factual truth or application permission. For text-rich records, continue with
+[narrative reuse](ecosystem.html) after this table example.
+
+Install with `pak::pak("JamesHWade/graft")` before running the guide. All evaluated
+chunks below use local synthetic records; the optional live-chat example is
+marked separately. The store closes at the end.
 
 ## Load a table contract
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -31,8 +31,8 @@ factual truth or application permission. For text-rich records, continue with
 [narrative reuse](ecosystem.html) after this table example.
 
 Install with `pak::pak("JamesHWade/graft")` before running the guide. All evaluated
-chunks below use local synthetic records; the optional live-chat example is
-marked separately. The store closes at the end.
+chunks below use local synthetic records. The optional live-chat call is shown
+but not evaluated and requires model credentials. The store closes at the end.
 
 ## Load a table contract
 


### PR DESCRIPTION
Related: [#42](https://github.com/JamesHWade/graft/issues/42).

Lead the site with durable knowledge, accepted history and exact reuse above data-dict. Keep the full offline tutorial at its existing URL, simplify task and integration navigation, correct broad safety/trust claims, and fix the floated-logo collision that crushed the hero at 320px. The existing staged build also excludes the internal CONTEXT.md glossary from pages and search and scans output directories recursively for internal artifacts. Website generation uses read-only permissions, with artifact deployment in a separate non-PR job.

Validation: pkgdown reference checks and the repository's full deployment build pass, including offline articles and internal-file exclusion. All 2,227 local links/assets resolve. Homepage, quickstart, ecosystem and graft_tools reference were visually reviewed at 320/768/1280 pixels in light/dark modes; native menus, theme switching, keyboard search, focus and overflow were checked. The audit is in tools/site-refresh-review.md. Existing URLs and the gh-pages deployment path are preserved. The prior site head passed all 16 checks and its review threads are resolved. All final-head checks pass on aa4afbf, including the complete three-OS package suite and dedicated producer compatibility jobs. Linux/macOS pass 2,236 assertions; Windows passes 2,233 with its existing platform skip. Linux/macOS retain a temporary uv-lock R CMD check note; Windows reports Status: OK.

The homepage keeps the still-open Tempest restart integration scoped to #50, consistent with the integration guides. The final deployment build passes. Published-site verification remains required after an authorized merge and deployment.


PR tests now run in four isolated processes, starting the measured slow files first. Installed-layout schema fixtures are staged separately so workers do not overwrite shared inputs. The local parallel suite passes 2,235 assertions in 183.1 seconds with no failures or warnings; four optional producer-CLI checks remain skipped locally and retain dedicated CI coverage. A matched serial benchmark was interrupted by a full local disk, so no exact speedup is claimed. The installed-layout schema probe passes all 111 assertions after normalizing isolated fixture paths. Full three-OS package tests remain on every PR. Instrumented coverage runs on main pushes and manual dispatch, and stale CI runs are cancelled.
