### PR TITLE
Prove Reader-isolated knowledge reads and host authorization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # graft 0.0.0.9000
 
+* A new Reader access guide and offline two-Reader contract demonstrate isolated stores, host authorization, pinned tool results, revocation, and safe worker rebinds; Rill runtime integration and permanent Forget remain separate gates (#47).
 * Agent integrations now require ellmer 0.5.0 or later; `graft_tools()` and `graft_verify()` reject older installations explicitly instead of risking omitted answers from incompatible transcript classes (#36).
 * `graft_commons_data_source()` now supports current Commons sources without a version or revision pin, retains its detached connection without modifying Commons fields, and checks the public constructor interface (#36).
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ it and authority to execute code. Acceptance is not factual truth.
 Follow the [offline quickstart](https://jameshwade.github.io/graft/articles/getting-started.html),
 try [narrative reuse](https://jameshwade.github.io/graft/articles/ecosystem.html),
 or retain an [exact reuse basis](https://jameshwade.github.io/graft/articles/reuse-basis.html).
+The [Reader access example](https://jameshwade.github.io/graft/articles/reader-access.html)
+shows separate stores and host authorization with two synthetic Readers.
 The tested agent recipes use ellmer, Deputy and dsprrr. Commons receives a
 detached public source; LinkML supports richer graph domains.
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -59,6 +59,8 @@ navbar:
           href: articles/agents.html
         - text: Reuse narrative knowledge
           href: articles/ecosystem.html
+        - text: Keep Readers' knowledge separate
+          href: articles/reader-access.html
         - text: Supported integrations
           href: articles/compatibility.html
     design:
@@ -104,6 +106,7 @@ articles:
       - compatibility
       - ecosystem
       - reuse-basis
+      - reader-access
   - title: Add richer representations
     desc: >
       Add semantic graph relationships with LinkML or synchronize a readable

--- a/adr/0005-isolate-reader-knowledge-stores.md
+++ b/adr/0005-isolate-reader-knowledge-stores.md
@@ -1,0 +1,134 @@
+---
+status: proposed
+---
+
+# Isolate Reader knowledge in separate stores
+
+For the first Rill integration, use one Graft store per Reader behind a
+Rill-owned authorization boundary. This is the proposed host design and offline
+contract for [Graft #47](https://github.com/JamesHWade/graft/issues/47), not a
+deployed Rill feature or a new Graft access API. The executable example is
+`inst/examples/reader-access.R`; `tests/testthat/test-reader-access.R` exercises
+real stores, receipts, an ellmer loop, and a fresh R process.
+
+## Why this boundary
+
+Graft can read an accepted boundary, but it does not authenticate Readers.
+An `owner_binding` column, a class filter, `display: restricted`, or a snapshot
+does not authorize access. Filtering one query in a shared store would leave
+history, changes, relationships, dictionary metadata, calculations, counts,
+and receipt resolution as independent disclosure paths.
+
+| Option | Consequence | Decision |
+| --- | --- | --- |
+| Separate store per Reader | Existing public reads see only that Reader's accepted records. Rill must bind storage, execution, and source access to the authenticated Reader. | Use for the first proof and propose for the initial host integration. |
+| Shared store with a scoped read capability | Every direct read, definition, dependency, diagnostic, receipt, and historical boundary must enforce the same scope before selection and aggregation. DuckDB file access is not a Reader authorization boundary. | Defer until a real consumer demonstrates that separate stores are insufficient. |
+| A shared store filtered by `owner_id` | Unfiltered APIs and derived results can reveal private data or its existence. | Reject. |
+
+No generic scope class, new schema language, or implicit Reader column is
+required by this proof. Graft continues to own accepted records and exact
+boundaries; Rill owns Reader identity, admission, source access, task purpose,
+and consultation eligibility.
+
+## Host and storage constraints
+
+Rill's [runtime ADR](https://github.com/JamesHWade/rill/blob/main/docs/adr/0001-hosted-rill-runtime-and-identity.md)
+and [Agent Run ADR](https://github.com/JamesHWade/rill/blob/main/docs/adr/0005-keep-agent-runs-durable-and-execution-process-local.md)
+describe one web process, PostgreSQL product records, process-local execution,
+and a separate poller. The deployment guide does not establish a durable Graft
+disk or a knowledge-store connection lifecycle.
+
+A [Render persistent disk](https://render.com/docs/disks) would require a
+storage/deployment decision: files survive only under its mount; the disk is
+attached to one service instance and is unavailable to the separate cron
+service. A disk-backed service also loses zero-downtime deployment. The proof
+uses temporary local files and makes no claim about deployed persistence.
+
+[DuckDB's embedded concurrency contract](https://duckdb.org/docs/current/connect/concurrency)
+supports a writing process or multiple read-only processes. Rill must coordinate
+writers with external readers; reopening a file does not establish safe
+concurrent access. The example closes its writer before a worker opens a
+read-only connection. It does not copy an active database or pass connections
+between processes. A future service or remote backend needs separate evidence.
+
+The host must provision stores on durable storage, record their UUIDs in its
+trusted Reader mapping, serialize incompatible access, and verify backup and
+restore before rollout. A missing or mismatched store fails closed; opening a
+new empty store is not recovery.
+
+## Authorization and reference resolution
+
+Only verified host identity selects a Reader. Neither model arguments nor
+serialized reuse bases select a Reader, filesystem path, schema, credential,
+or live database handle. A trusted host registry maps that Reader to a store
+path, schema, and expected store UUID. The example verifies the UUID after a
+read-only open, then resolves any snapshot against that store.
+
+Before lookup, the host supplies a nonempty current grant revision. After
+reading, the revision must still match. Revocation or a revoke/regrant cycle
+changes that revision and prevents release of the result. The production host
+must obtain it from its current authorization state, not a stale session copy.
+The example's in-memory grants are synthetic policy inputs, not authentication.
+
+The read callback is trusted application code. It must return collected values,
+not a store, view, closure, or connection. The model receives only the declared
+record tool; it cannot supply a callback, Reader, SQL, path, or arbitrary R code.
+Separate files do not sandbox hostile code running under the host's OS account.
+
+The tool checks authorization at construction and again on every invocation.
+It uses a pinned `graft_get()` result and its complete canonical receipt. A
+foreign snapshot is rejected even when the other store has the same schema
+and record ID. Receipt identities identify evidence; possession of one grants
+no access. Graft's verification label still assesses the recorded evidence path,
+not Reader authentication or factual accuracy.
+
+Unknown records, foreign records, invalid references, revoked access, and
+storage failures produce the same content-free boundary error, without an
+underlying exception attached. This avoids an existence oracle or leaking a
+private path through an error. Rill should record a separate content-free
+operational failure category. Equal response timing is not established here.
+
+## Sources, caches, and lifecycle
+
+Each Reader's private capture keeps its own logical Document revision and
+provenance, including when the original URL or bytes match another Reader's
+capture. A shared URL never resolves a foreign record. Cross-store foreign
+keys fail validation; an authorized handoff must explicitly import an allowed
+copy and preserve its source revision under the receiving host's ownership.
+Rill still authorizes hydration of external Documents under
+[its Library ADR](https://github.com/JamesHWade/rill/blob/main/docs/adr/0007-separate-shared-sources-from-reader-libraries.md).
+This example's synthetic source rows do not prove that Rill hydration path.
+
+The recipe caches neither results nor connections. Reconnects and workers
+reconstruct access from trusted host state and recheck authorization before
+reading a saved basis. A production cache must include Reader, store UUID,
+accepted boundary, selection, and current grant revision in its ownership
+contract, and check access on a cache hit. Cross-Reader cache reuse is forbidden.
+
+Revocation stops subsequent reads; it cannot retract content already returned
+to a model, Conversation, or client. The host must cancel affected runs and
+discard their reusable context before proceeding. Archive and consultation
+eligibility follow the separate reuse contract. Permanent Forget must also
+remove derived copies and prevent restoration from backups; it remains gated
+by [#48](https://github.com/JamesHWade/graft/issues/48). No erasure is implemented
+by this access recipe.
+
+## Bounded implementation handoff
+
+[Graft #51](https://github.com/JamesHWade/graft/issues/51) and
+[Rill #7](https://github.com/JamesHWade/rill/issues/7) own the product follow-through:
+
+1. Resolve verified identity to a Reader and a durable store binding. Test
+   admission changes, missing stores, substituted UUIDs, and reconnects using
+   Rill's actual store and Agent Run objects.
+2. Map accepted Reading Artifacts and Reader Memory with exact private
+   Document revisions. Test guessed IDs, cross-Reader relationships and source
+   hydration, including equal URLs and bytes.
+3. Bind the narrow tool to each run, enforce current access on invocation and
+   delivery, cancel affected runs on revocation, and prohibit shared result or
+   conversation caches. Recheck task eligibility separately.
+4. Establish durable storage, connection ownership, recoverable backup, and
+   permanent Forget across authoritative and derived copies under #48.
+
+The Graft-side proof can be reviewed independently. Rill integration and its
+production access/erasure gates remain open until these host tests pass.

--- a/inst/examples/reader-access.R
+++ b/inst/examples/reader-access.R
@@ -1,0 +1,133 @@
+# Application-owned teaching recipe, not an authentication or Graft access API.
+# The Reader, locator, grant revision, and read callback are trusted host inputs.
+reader_knowledge_unavailable <- function() {
+  stop(structure(
+    list(message = "Accepted knowledge is unavailable.", call = NULL),
+    class = c("reader_knowledge_unavailable", "error", "condition")
+  ))
+}
+
+reader_knowledge_access <- function(reader, locate, grant) {
+  force(reader)
+  force(locate)
+  force(grant)
+  read_once <- function(read) {
+    revision <- grant(reader)
+    if (
+      !is.character(revision) ||
+        length(revision) != 1L ||
+        is.na(revision) ||
+        !nzchar(revision)
+    ) {
+      reader_knowledge_unavailable()
+    }
+    location <- locate(reader)
+    store <- graft::graft_open(
+      graft::graft_schema(location$schema),
+      location$path,
+      read_only = TRUE,
+      okf = "disabled"
+    )
+    on.exit(graft::graft_close(store))
+    if (!identical(graft::graft_snapshot(store)@store_id, location$store_id)) {
+      reader_knowledge_unavailable()
+    }
+    value <- read(store)
+    if (!identical(grant(reader), revision)) {
+      reader_knowledge_unavailable()
+    }
+    value
+  }
+  function(read) {
+    tryCatch(read_once(read), error = function(error) {
+      reader_knowledge_unavailable()
+    })
+  }
+}
+
+reader_record_tool <- function(access, snapshot) {
+  force(access)
+  force(snapshot)
+  access(function(store) {
+    graft::graft_at(store, snapshot)
+    NULL
+  })
+  ellmer::tool(
+    function(id) {
+      access(function(store) {
+        view <- graft::graft_at(store, snapshot)
+        graft::graft_tools(view, result_format = "json")$graft_get(id)
+      })
+    },
+    name = "graft_get",
+    description = "Read one accepted record from this Reader's pinned knowledge.",
+    arguments = list(id = ellmer::type_string("Accepted record identifier.")),
+    annotations = list(
+      read_only_hint = TRUE,
+      destructive_hint = FALSE,
+      open_world_hint = FALSE
+    )
+  )
+}
+
+# Synthetic fixture only. The same public schema and one colliding local ID
+# deliberately prevent schema names or globally unique IDs from hiding errors.
+reader_access_fixture <- function(directory) {
+  schema <- system.file(
+    "extdata/narrative-knowledge.data-dict.json",
+    package = "graft",
+    mustWork = TRUE
+  )
+  narrative <- new.env()
+  sys.source(
+    system.file("examples/narrative-knowledge.R", package = "graft"),
+    narrative
+  )
+  create <- function(reader) {
+    path <- file.path(directory, paste0(reader, ".duckdb"))
+    store <- graft::graft_open(
+      graft::graft_schema(schema),
+      path,
+      okf = "disabled"
+    )
+    on.exit(graft::graft_close(store))
+    records <- narrative$narrative_records()
+    qualify <- function(ids) {
+      ifelse(ids == "knowledge:preference", ids, paste0(ids, ":", reader))
+    }
+    records <- lapply(records, function(table) {
+      table$id <- qualify(table$id)
+      table
+    })
+    records$knowledge$body <- paste(reader, records$knowledge$body)
+    records$knowledge$owner_binding <- paste0("private-owner-", reader)
+    records$source$document_revision <- paste0("private-document-", reader)
+    records$source$quote <- paste(
+      reader,
+      "private capture from https://example.org/report"
+    )
+    records$support$knowledge_id <- qualify(records$support$knowledge_id)
+    records$support$source_id <- qualify(records$support$source_id)
+    if (reader == "bob") {
+      records$knowledge <- records$knowledge[1:3, ]
+    }
+    records$GraftDefinition <- data.frame(
+      name = "knowledge_count",
+      target = "knowledge",
+      expr = "ROW_COUNT()"
+    )
+    graft::graft_ingest(
+      store,
+      records,
+      graft::graft_provenance(paste0("host-", reader), idempotency_key = "seed")
+    )
+    snapshot <- graft::graft_snapshot(store)
+    list(
+      path = path,
+      schema = schema,
+      store_id = snapshot@store_id,
+      snapshot = snapshot
+    )
+  }
+  stats::setNames(lapply(c("alice", "bob"), create), c("alice", "bob"))
+}

--- a/tests/testthat/helper-reader-access.R
+++ b/tests/testthat/helper-reader-access.R
@@ -1,0 +1,29 @@
+reader_access_example <- function() {
+  env <- new.env(parent = environment())
+  sys.source(system.file("examples/reader-access.R", package = "graft"), env)
+  env
+}
+
+local_reader_access <- function(.local_envir = parent.frame()) {
+  example <- reader_access_example()
+  directory <- withr::local_tempdir(.local_envir = .local_envir)
+  locations <- example$reader_access_fixture(directory)
+  grants <- new.env(parent = emptyenv())
+  grants$alice <- "alice-grant-1"
+  grants$bob <- "bob-grant-1"
+  bind <- function(reader) {
+    example$reader_knowledge_access(
+      reader,
+      locate = \(reader) locations[[reader]],
+      grant = \(reader) grants[[reader]]
+    )
+  }
+  list(
+    example = example,
+    locations = locations,
+    grants = grants,
+    bind = bind,
+    alice = bind("alice"),
+    bob = bind("bob")
+  )
+}

--- a/tests/testthat/test-reader-access.R
+++ b/tests/testthat/test-reader-access.R
@@ -37,7 +37,10 @@ test_that("isolated Readers cannot discover each other's records or counts", {
       values$dictionary$receipt$store$id,
       host$locations[[reader]]$store_id
     )
-    expect_identical(grepl(other, canonical_json(values)), FALSE)
+    expect_identical(
+      grepl(paste0("\\b", other, "\\b"), canonical_json(values)),
+      FALSE
+    )
     expect_identical(grepl("private-owner-", canonical_json(values)), FALSE)
     expect_equal(values$count$knowledge_count, if (reader == "alice") 4 else 3)
     expect_contains(values$tools, "graft_calculate")

--- a/tests/testthat/test-reader-access.R
+++ b/tests/testthat/test-reader-access.R
@@ -1,0 +1,311 @@
+test_that("isolated Readers cannot discover each other's records or counts", {
+  host <- local_reader_access()
+  for (reader in c("alice", "bob")) {
+    other <- if (reader == "alice") "bob" else "alice"
+    access <- host[[reader]]
+    values <- access(function(store) {
+      snapshot <- graft_snapshot(store)
+      view <- graft_at(store, snapshot)
+      list(
+        own = graft_get(view, "knowledge:preference"),
+        search = graft_find(view, other),
+        history = graft_history(
+          view,
+          paste0("knowledge:interpretation:", reader)
+        ),
+        changes = graft_changes(
+          view,
+          record_ids = paste0("source:trial-v1:", other)
+        ),
+        all_changes = graft_changes(view),
+        dictionary = graft_dictionary(view, limit = 2L),
+        page = graft_dictionary(view, limit = 2L, offset = 2L),
+        source = graft_get(view, paste0("source:trial-v1:", reader)),
+        support = graft_get(view, paste0("support:interpretation:", reader)),
+        count = graft_calculate(view, "knowledge_count"),
+        tools = names(graft_tools(view))
+      )
+    })
+    expect_match(values$own$record$body, paste0("^", reader))
+    expect_equal(nrow(values$search), 0L)
+    expect_equal(nrow(values$history), 1L)
+    expect_equal(nrow(values$changes), 0L)
+    expect_equal(nrow(values$all_changes), if (reader == "alice") 8L else 7L)
+    expect_identical(values$dictionary$receipt, values$page$receipt)
+    expect_equal(nrow(values$page$result$entries), 2L)
+    expect_identical(
+      values$dictionary$receipt$store$id,
+      host$locations[[reader]]$store_id
+    )
+    expect_identical(grepl(other, canonical_json(values)), FALSE)
+    expect_identical(grepl("private-owner-", canonical_json(values)), FALSE)
+    expect_equal(values$count$knowledge_count, if (reader == "alice") 4 else 3)
+    expect_contains(values$tools, "graft_calculate")
+    for (id in c(paste0("knowledge:interpretation:", other), "absent")) {
+      error <- tryCatch(access(\(store) graft_get(store, id)), error = identity)
+      expect_s3_class(error, "reader_knowledge_unavailable")
+      expect_identical(
+        conditionMessage(error),
+        "Accepted knowledge is unavailable."
+      )
+      expect_null(error$parent)
+      expect_error(
+        access(\(store) graft_history(store, id)),
+        class = "reader_knowledge_unavailable"
+      )
+    }
+  }
+})
+
+test_that("foreign snapshots, relationships, and changed store mappings fail closed", {
+  host <- local_reader_access()
+  expect_error(
+    host$alice(\(store) graft_at(store, host$locations$bob$snapshot)),
+    class = "reader_knowledge_unavailable"
+  )
+  expect_error(
+    host$alice(\(store) {
+      graft_changes(store, since = host$locations$bob$snapshot)
+    }),
+    class = "reader_knowledge_unavailable"
+  )
+  plan <- host$alice(function(store) {
+    graft_plan(
+      store,
+      list(
+        support = data.frame(
+          id = "support:foreign",
+          knowledge_id = "knowledge:interpretation:alice",
+          source_id = "source:trial-v1:bob",
+          anchor = "paragraph:1"
+        )
+      ),
+      graft_provenance("synthetic-host")
+    )
+  })
+  expect_identical(plan@valid, FALSE)
+  swapped <- host$locations$alice
+  swapped$path <- host$locations$bob$path
+  access <- host$example$reader_knowledge_access(
+    "alice",
+    \(reader) swapped,
+    \(reader) "grant-1"
+  )
+  expect_error(access(graft_snapshot), class = "reader_knowledge_unavailable")
+  missing <- host$locations$alice
+  missing$path <- withr::local_tempfile(fileext = ".duckdb")
+  access <- host$example$reader_knowledge_access(
+    "alice",
+    \(reader) missing,
+    \(reader) "grant-1"
+  )
+  expect_error(access(graft_snapshot), class = "reader_knowledge_unavailable")
+  expect_identical(file.exists(missing$path), FALSE)
+  expect_error(
+    host$alice(\(store) {
+      graft_query(store, "neighbors", list(id = "source:trial-v1:bob"))
+    }),
+    class = "reader_knowledge_unavailable"
+  )
+})
+
+test_that("revocation blocks construction and old tools without returning cached content", {
+  host <- local_reader_access()
+  tool <- host$example$reader_record_tool(
+    host$alice,
+    host$locations$alice$snapshot
+  )
+  expected <- tool("knowledge:preference")
+  expect_match(expected, "alice Prefer short")
+  host$grants$alice <- NULL
+  expect_error(
+    tool("knowledge:preference"),
+    class = "reader_knowledge_unavailable"
+  )
+  expect_error(
+    host$example$reader_record_tool(host$alice, host$locations$alice$snapshot),
+    class = "reader_knowledge_unavailable"
+  )
+  host$grants$alice <- "alice-grant-2"
+  expect_identical(tool("knowledge:preference"), expected)
+  value <- "not released"
+  expect_error(
+    value <- host$alice(function(store) {
+      result <- graft_get(store, "knowledge:preference")
+      host$grants$alice <- "alice-grant-3"
+      result
+    }),
+    class = "reader_knowledge_unavailable"
+  )
+  expect_identical(value, "not released")
+  host$grants$alice <- NULL
+  expect_match(
+    host$bob(\(store) graft_get(store, "knowledge:preference"))$record$body,
+    "^bob"
+  )
+  opened <- 0L
+  denied <- host$example$reader_knowledge_access(
+    "alice",
+    function(reader) {
+      opened <<- opened + 1L
+      host$locations[[reader]]
+    },
+    \(reader) NULL
+  )
+  expect_error(denied(graft_snapshot), class = "reader_knowledge_unavailable")
+  expect_identical(opened, 0L)
+})
+
+test_that("reopened tools preserve pinned receipts after an accepted correction", {
+  host <- local_reader_access()
+  tool <- host$example$reader_record_tool(
+    host$alice,
+    host$locations$alice$snapshot
+  )
+  before <- tool("knowledge:preference")
+  location <- host$locations$alice
+  writer <- graft_open(
+    graft_schema(location$schema),
+    location$path,
+    okf = "disabled"
+  )
+  withr::defer(graft_close(writer))
+  record <- narrative_fixture()$narrative_records()$knowledge[3L, ]
+  record$body <- "alice Prefer reading in the evening."
+  record$owner_binding <- "private-owner-alice"
+  graft_ingest(
+    writer,
+    list(knowledge = record),
+    graft_provenance("synthetic-host")
+  )
+  after <- graft_snapshot(writer)
+  graft_close(writer)
+  expect_identical(tool("knowledge:preference"), before)
+  current <- host$example$reader_record_tool(host$alice, after)
+  expect_match(current("knowledge:preference"), "evening")
+  changes <- host$alice(\(store) {
+    graft_changes(
+      store,
+      since = host$locations$alice$snapshot
+    )
+  })
+  expect_identical(changes$record_id, "knowledge:preference")
+  expect_identical(changes$action, "update")
+})
+
+test_that("agent tool calls bind to the authenticated host rather than an argument", {
+  withr::local_options(lifecycle_verbosity = "error")
+  host <- local_reader_access()
+  tool <- host$example$reader_record_tool(
+    host$alice,
+    host$locations$alice$snapshot
+  )
+  server <- local_host_responses(
+    list(
+      list(name = "graft_get", arguments = list(id = "knowledge:preference")),
+      list(
+        name = "graft_get",
+        arguments = list(id = "knowledge:interpretation:bob")
+      ),
+      list(
+        name = "graft_get",
+        arguments = list(id = "knowledge:preference", reader = "bob")
+      ),
+      list(name = "graft_find", arguments = list(query = "bob"))
+    ),
+    "The available record belongs to Alice."
+  )
+  chat <- host_chat(server)
+  chat$set_tools(list(graft_get = tool))
+  expect_warning(
+    chat$chat("Read accepted knowledge.", echo = "none"),
+    class = "ellmer_tool_failure"
+  )
+  values <- host_result_values(chat)
+  expect_identical(values[[1L]], tool("knowledge:preference"))
+  expect_identical(
+    grepl("bob private|bob Prefer|private-owner-", canonical_json(values)),
+    FALSE
+  )
+  expect_identical(graft_verify(chat)$label[[1L]], "untrusted")
+  expect_named(chat$get_tools(), "graft_get")
+})
+
+test_that("fresh workers rebind trusted locations and reject another Reader's basis", {
+  host <- local_reader_access()
+  basis <- host$alice(function(store) {
+    reuse_example()$capture_reuse_basis(
+      store,
+      "knowledge:preference",
+      data.frame(outcome = character(), dependency = character())
+    )
+  })
+  checkpoint <- withr::local_tempfile(fileext = ".rds")
+  saveRDS(basis, checkpoint)
+  result <- callr::r(
+    function(checkout, locations, checkpoint) {
+      if (!is.null(checkout)) {
+        pkgload::load_all(checkout, quiet = TRUE)
+      }
+      example <- new.env()
+      sys.source(
+        system.file("examples/reader-access.R", package = "graft"),
+        example
+      )
+      sys.source(
+        system.file("examples/reuse-basis.R", package = "graft"),
+        example
+      )
+      basis <- readRDS(checkpoint)
+      read <- function(reader) {
+        access <- example$reader_knowledge_access(
+          reader,
+          \(reader) locations[[reader]],
+          \(reader) "worker-grant-1"
+        )
+        tryCatch(
+          access(\(store) example$read_reuse_basis(store, basis, \(ids) TRUE)),
+          reader_knowledge_unavailable = conditionMessage
+        )
+      }
+      list(alice = read("alice"), bob = read("bob"))
+    },
+    args = list(
+      checkout = if (pkgload::is_dev_package("graft")) {
+        normalizePath(test_path("../.."))
+      } else {
+        NULL
+      },
+      locations = host$locations,
+      checkpoint = checkpoint
+    )
+  )
+  expect_match(result$alice[[1L]]$body, "^alice")
+  expect_identical(result$bob, "Accepted knowledge is unavailable.")
+  expect_named(
+    basis,
+    c("version", "snapshot", "roots", "records", "dependencies")
+  )
+})
+
+test_that("a real Deputy run retains the authorized Reader's receipt and citation", {
+  skip_if_not_installed("deputy")
+  withr::local_options(lifecycle_verbosity = "error")
+  host <- local_reader_access()
+  tool <- host$example$reader_record_tool(host$bob, host$locations$bob$snapshot)
+  server <- local_host_responses(
+    list(list(
+      name = "graft_get",
+      arguments = list(id = "knowledge:preference")
+    )),
+    "> bob Prefer short reading sessions in the morning; this is a preference, not source evidence."
+  )
+  chat <- host_chat(server)
+  run_graft_host("deputy", chat, list(graft_get = tool))
+  expect_identical(host_result_values(chat), list(tool("knowledge:preference")))
+  expect_identical(graft_verify(chat)$label[[1L]], "cited")
+  expect_identical(
+    grepl("alice|private-owner-", canonical_json(host_result_values(chat))),
+    FALSE
+  )
+})

--- a/vignettes/reader-access.Rmd
+++ b/vignettes/reader-access.Rmd
@@ -1,0 +1,134 @@
+---
+title: "Keep Readers' accepted knowledge separate"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Keep Readers' accepted knowledge separate}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(graft)
+```
+
+Two Readers may accept different interpretations of the same article. A later
+task must use the authenticated Reader's accepted knowledge, even if another
+Reader has the same record ID. This offline example opens a separate Graft
+store for each Reader and checks host authorization before every read.
+
+This is an application-owned teaching recipe for
+[#47](https://github.com/JamesHWade/graft/issues/47). It uses synthetic records
+and grants, not Rill authentication. The
+[storage and access proposal](https://github.com/JamesHWade/graft/blob/main/adr/0005-isolate-reader-knowledge-stores.md)
+compares separate stores with shared scoped reads and specifies the remaining
+Rill work. No Graft access-control API is added.
+
+## Bind access in the host
+
+The host supplies the Reader, store locator, and current grant revision. These
+inputs must never come from model arguments or a saved reuse basis. The recipe
+opens read-only, checks the expected store UUID, collects the read, rechecks the
+grant revision, and closes the connection. It returns a generic error when any
+step fails.
+
+```{r bind}
+example <- new.env()
+sys.source(system.file("examples/reader-access.R", package = "graft"), example)
+directory <- tempfile("reader-access-")
+dir.create(directory)
+locations <- example$reader_access_fixture(directory)
+grants <- new.env()
+grants$alice <- "alice-grant-1"
+grants$bob <- "bob-grant-1"
+bind <- function(reader) {
+  example$reader_knowledge_access(
+    reader,
+    locate = \(reader) locations[[reader]],
+    grant = \(reader) grants[[reader]]
+  )
+}
+alice <- bind("alice")
+bob <- bind("bob")
+alice(\(store) graft_get(store, "knowledge:preference"))$record$body
+bob(\(store) graft_get(store, "knowledge:preference"))$record$body
+```
+
+The colliding ID resolves inside the selected store. A foreign ID and an
+unavailable ID produce the same boundary error. Search and accepted
+calculations only observe the selected Reader's data.
+
+```{r scope}
+unavailable <- function(read) {
+  tryCatch(read(), reader_knowledge_unavailable = conditionMessage)
+}
+unavailable(\() alice(\(store) graft_get(store, "knowledge:interpretation:bob")))
+unavailable(\() alice(\(store) graft_get(store, "absent")))
+alice(\(store) nrow(graft_find(store, "bob")))
+alice(\(store) graft_calculate(store, "knowledge_count"))
+bob(\(store) graft_calculate(store, "knowledge_count"))
+```
+
+Separate files matter here: a column marked `display: restricted` only omits
+that column. It does not authorize a Reader, filter other records, or protect
+aggregates in a shared store. The host's callback is trusted R code; do not
+expose it, filesystem access, or an R evaluator to the model.
+
+## Pin a tool without freezing permission
+
+The tool exposes only a record ID. It obtains its complete JSON result and
+receipt from `graft_tools()` after reopening the authorized store at the pinned
+boundary. Revoking access after construction prevents the next call.
+
+```{r tool}
+tool <- example$reader_record_tool(alice, locations$alice$snapshot)
+value <- jsonlite::fromJSON(tool("knowledge:preference"))
+value$result$record$body
+identical(value$receipt$store$id, locations$alice$store_id)
+grants$alice <- NULL
+unavailable(\() tool("knowledge:preference"))
+bob(\(store) graft_get(store, "knowledge:preference"))$record$body
+```
+
+The same callback rejects a changed grant revision during a read, including a
+revoke/regrant cycle. Content already delivered to a model or client remains a
+host lifecycle concern: cancel affected runs and discard their reusable context.
+Permanent erasure and backup restore remain separate work in
+[#48](https://github.com/JamesHWade/graft/issues/48).
+
+## Reconnect with a complete basis
+
+Persist the [complete selected basis](reuse-basis.html), then reconstruct the
+Reader's access from trusted host state in the new session or worker. The
+checkpoint contains no locator or credentials. A basis from another store fails
+even when its selected record ID exists locally.
+
+```{r rebind}
+grants$alice <- "alice-grant-2"
+sys.source(system.file("examples/reuse-basis.R", package = "graft"), example)
+basis <- alice(\(store) example$capture_reuse_basis(
+  store,
+  "knowledge:preference",
+  data.frame(outcome = character(), dependency = character())
+))
+checkpoint <- file.path(directory, "basis.rds")
+saveRDS(basis, checkpoint)
+restored <- readRDS(checkpoint)
+reconnected <- bind("alice")
+reconnected(\(store) example$read_reuse_basis(store, restored, \(ids) TRUE))
+unavailable(\() bob(\(store) example$read_reuse_basis(store, restored, \(ids) TRUE)))
+```
+
+Here the inner callback permits the complete selection because the outer access
+boundary already authorizes this Reader's store. A product must additionally
+apply its current consultation-eligibility policy. Package tests repeat the
+rebind in a separate R process, with all writer connections closed first.
+
+The example proves isolated Graft reads and host tool composition. It does not
+establish durable hosting, concurrent writer access, Rill's Document hydration,
+or permanent Forget. Those gates remain explicit in
+[#51](https://github.com/JamesHWade/graft/issues/51) and the access proposal.
+
+```{r cleanup, include=FALSE}
+unlink(directory, recursive = TRUE)
+```

--- a/vignettes/reuse-basis.Rmd
+++ b/vignettes/reuse-basis.Rmd
@@ -144,7 +144,9 @@ Permanent Forget is stronger: old snapshots, checkpoints, caches and backups
 must not restore erased content. The teaching callback proves host refusal, not
 physical erasure. Graft's permanent purge and restore contract remains
 [#48](https://github.com/JamesHWade/graft/issues/48), and Reader access remains
-[#47](https://github.com/JamesHWade/graft/issues/47).
+[#47](https://github.com/JamesHWade/graft/issues/47). The
+[two-Reader access example](reader-access.html) demonstrates isolated stores and
+current authorization checks before a saved basis is read.
 
 ## Consumer status
 


### PR DESCRIPTION
A model-facing record read must stay within the authenticated Reader's accepted knowledge, including after reconnects and when two stores contain the same record ID. This adds a Graft-side design and executable proof for #47, using separate stores selected by trusted host state.

The teaching recipe opens the bound store read-only, checks its UUID, checks a current grant revision before and after the read, and returns a content-free error for inaccessible data. Its narrow ellmer tool preserves Graft's pinned JSON envelope and receipt. The tests cover guessed IDs, search, history, changes, dictionary pages, accepted counts, foreign references and snapshots, substituted/missing stores, revocation, corrections, fresh workers, and real ellmer/Deputy runs.

The proposed ADR compares separate stores with shared scoped reads and records the Rill storage, source-access, run-cancellation, and cache requirements. This is an offline host contract; Rill runtime implementation (#51) and permanent Forget/backup/restore (#48) remain open. No exported API or consumer contract version changes.

Validation:

- `devtools::test(filter = "^reader-access")`: 71 passing assertions, no failures, warnings, or skips.
- Package check: zero errors, warnings, or notes, with tests and vignette execution checked separately.
- `Rscript tools/build-pkgdown.R`: complete site build and runnable guide passed; 2,330 local links/assets resolve.
- Desktop and 320px mobile visual review, pkgdown reference coverage, Air, Jarl, and `git diff --check` passed.

The runnable walkthrough is `vignettes/reader-access.Rmd`; the app-owned recipe is `inst/examples/reader-access.R`.

All 13 CI checks passed on `219d8cc`, including all three operating-system package checks. Linux passed 2,372 assertions (four optional CLI tests run separately in compatibility CI); Windows passed 2,369 assertions with the same optional CLI skips and its existing platform skip. Linux reported the same temporary `uv` lock-file note as the merged baseline; there were no test failures or warnings.
