### PR TITLE
Design Forget recovery and prove retired backup rejection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # graft 0.0.0.9000
 
+* A proposed Forget and recovery protocol has offline tests for retired store generations, backup admission, interrupted cleanup, and Reader isolation; permanent purge and production recovery remain unimplemented (#48).
 * A new Reader access guide and offline two-Reader contract demonstrate isolated stores, host authorization, pinned tool results, revocation, and safe worker rebinds; Rill runtime integration and permanent Forget remain separate gates (#47).
 * Agent integrations now require ellmer 0.5.0 or later; `graft_tools()` and `graft_verify()` reject older installations explicitly instead of risking omitted answers from incompatible transcript classes (#36).
 * `graft_commons_data_source()` now supports current Commons sources without a version or revision pin, retains its detached connection without modifying Commons fields, and checks the public constructor interface (#36).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ try [narrative reuse](https://jameshwade.github.io/graft/articles/ecosystem.html
 or retain an [exact reuse basis](https://jameshwade.github.io/graft/articles/reuse-basis.html).
 The [Reader access example](https://jameshwade.github.io/graft/articles/reader-access.html)
 shows separate stores and host authorization with two synthetic Readers.
+The [Forget and recovery proposal](https://jameshwade.github.io/graft/articles/forget-restore.html)
+uses a synthetic backup proof to define the remaining erasure and recovery gates.
 The tested agent recipes use ellmer, Deputy and dsprrr. Commons receives a
 detached public source; LinkML supports richer graph domains.
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -70,6 +70,8 @@ navbar:
           href: articles/linkml-schema.html
         - text: Open knowledge
           href: articles/open-knowledge-format.html
+        - text: Design Forget and recovery
+          href: articles/forget-restore.html
         - text: Architecture
           href: articles/architecture.html
         - text: Contract compilers
@@ -119,6 +121,7 @@ articles:
       Understand storage and projection boundaries, contract compilation, and
       the choices behind the v0.1 package design.
     contents:
+      - forget-restore
       - architecture
       - contract-compilers
       - v01-design

--- a/adr/0006-retire-forgotten-generations-before-restore.md
+++ b/adr/0006-retire-forgotten-generations-before-restore.md
@@ -169,8 +169,11 @@ The test copies only closed databases and checks logical absence/file removal.
 
 `tests/testthat/test-forget-restore.R` runs against real synthetic Graft files,
 snapshots, receipts, histories and public reads. Its test-only helper supplies a
-single-writer journal and a known-data replacement builder. Fault hooks exercise
-accepted, validated, partially removed, and published states; a fresh R process
+single-writer journal and a known-data replacement builder. Its certifier compares retained logical revisions against the original synthetic
+authority, including private fields, while excluding replay timestamps. Candidate
+paths are registered in the synthetic operational journal before validation so
+rejected or abandoned files and backup sidecars remain cleanup obligations.
+Fault hooks exercise accepted, validated, partially removed, and published states; a fresh R process
 checks the persisted denial decision. Placeholder files stand in for OKF,
 cache, checkpoint and Conversation disposal obligations. They do **not** prove
 actual OKF/export, Rill, provider, or filesystem erasure behavior. The original

--- a/adr/0006-retire-forgotten-generations-before-restore.md
+++ b/adr/0006-retire-forgotten-generations-before-restore.md
@@ -1,0 +1,205 @@
+---
+status: proposed
+---
+
+# Retire forgotten generations before restore
+
+For [#48](https://github.com/JamesHWade/graft/issues/48), propose a host-owned
+Forget journal independent of knowledge backups, plus replacement of the
+entire affected Reader's store generation. A retired generation can never be
+served again. This is a storage/API proposal and offline protocol proof; Graft
+has no supported permanent purge or backup/restore API yet. Rill's production
+gate remains open.
+
+This extends [the Reader isolation proposal](0005-isolate-reader-knowledge-stores.md).
+It deliberately qualifies immutable-history expectations: Forget makes old
+content unavailable, including content addressed by an old snapshot or reuse
+basis. It does not silently reinterpret an old receipt against a new store.
+
+## Inventory and ownership
+
+The inventory follows the current implementation, not just public query output.
+
+| Surface | Current copy and owner | Required treatment |
+| --- | --- | --- |
+| Accepted history | Graft `_graft_record_revisions` stores payload JSON, including private fields, old revisions, and digests; `_graft_record_heads` points at current revisions (`R/metadata.R`, `R/commit-executor.R`). | Remove every revision of selected records from the replacement; preserve allowed survivor history under an explicit migration contract. Removing a current projection is insufficient. |
+| Metadata and provenance | Graft batches, observations, identifiers, origins, schema manifests, and change metadata can contain source identifiers or user-supplied strings. | Inspect all fields for content and dependencies. Do not assume provenance, definitions, schema descriptions, or hashes are harmless audit metadata. |
+| Projections and indexes | Graft `_graft_current_records`, `_graft_projection_*`, relation projections, indexes and projection state (`R/projections.R`). | Rebuild from surviving authority in a new file. Include staging/temporary files and DuckDB WAL in disposal obligations. |
+| Managed OKF and exports | A file store defaults to a sibling `.okf` tree (`R/store.R`); `R/okf-managed.R` synchronizes it. `R/okf.R` can export historical snapshots; Markdown/front matter and detached exports contain readable copies. | Remove the old managed tree and inventoried exports; regenerate only from survivors. Prevent historical export/import from reopening a retired generation. |
+| Detached public views | `R/commons-adapter.R` materializes a separate Commons source and dictionary. Public means queryable under the contract, not public Internet data. | The consumer must invalidate/remove its copies, including returned calculation rows and dictionary prose. Graft cannot recall detached data by deleting its own rows. |
+| Caches and in-flight work | Host search indexes, query results, embeddings, model context, and process memory may hold payloads. | Block new reads, stop runs, discard buffered results, invalidate affected caches, and recheck epoch at delivery. Already disclosed client/provider content cannot be recalled by this protocol. |
+| Reuse bases and receipts | A minimal basis stores IDs/snapshot; host checkpoints or tool receipts may also retain rendered results, arguments, excerpts, or private IDs. | Inventory serialized content; purge payload-bearing copies. Keep only approved opaque audit identifiers. Old references resolve as unavailable, never to replacement revisions. |
+| Private Documents and evidence | Rill owns captures, extracted text, annotations, Source Evidence anchors, and hydration authorization. Equal URLs do not imply shared ownership. | Rill computes private dependency closure and removes matching derivatives. Retain an independently owned Reader's copy. Source deletion may require cascading to accepted outcomes that quote it. |
+| Conversations and accepted outcomes | Rill owns product semantics; shinychat presents durable Conversation history; Graft stores separately accepted Reader Memory/Reading Artifacts. | Deleting a Conversation alone leaves separately accepted outcomes. Forget of memory must identify its copied excerpts in retained Conversations separately, with a concrete preview and policy. |
+| Diagnostics and external destinations | Deputy execution/checkpoints, host logs, and opt-in Logfire/provider copies have distinct owners and retention. | Record requested, acknowledged, pending, or retention-limited disposal separately. Do not claim completed external deletion from a local success. |
+| Backups and storage remnants | Host database images, OKF archives, local snapshots, encrypted/offline backups, cloud replicas, filesystem/SSD remnants. | Deny retired images before opening; track disposal/key-retirement separately. Fresh replacement backup must be verified before service resumes. Physical secure erasure is outside this proof. |
+
+Sources for Rill's distinctions are [ADR 0002](https://github.com/JamesHWade/rill/blob/main/docs/adr/0002-keep-reader-semantics-in-rill-and-accepted-knowledge-in-graft.md),
+[ADR 0003](https://github.com/JamesHWade/rill/blob/main/docs/adr/0003-persist-conversations-and-accepted-reading-artifacts.md),
+and its [domain glossary](https://github.com/JamesHWade/rill/blob/main/CONTEXT.md).
+
+## Erasure boundary and authorization
+
+Rill computes a closure over its own private content dependencies, not merely
+foreign keys or string matches. The preview names the Reader, root records,
+all revisions, dependent accepted artifacts, copied passages, external
+obligations, and the effect on historical references. Authorize this exact
+preview, action `forget`, accepted boundary, and current access revision.
+Any intervening write or dependency change invalidates the preview. A generic
+write grant, model request, Archive approval, or possession of a receipt is not
+Forget authorization.
+
+For the synthetic schema, forgetting an interpretation removes its support
+record. Its source remains because another retained conclusion references it.
+Forgetting that source instead removes both supported outcomes and their
+support records; forgetting both outcomes also removes their unreferenced
+private source. Real Rill dependency closure must cover historical references
+and copied prose even after a current link was removed. Source ownership and
+copy provenance determine this; a model cannot decide the erasure boundary.
+
+A separately owned second Reader is outside the closure, even if IDs, URLs,
+or content match. The host must not erase that Reader's copy to satisfy the
+first Reader's request. This scoped guarantee must be clear in the preview.
+
+## Store generations and historical reads
+
+A generation is one closed, immutable database image with a store UUID,
+accepted snapshot, schema identity, format version, Reader binding, Forget
+epoch, and checksums for all bundled files. This is a backup/admission unit,
+not a new Graft runtime abstraction.
+
+Choose generation replacement for the first design rather than in-place row
+purging. It bounds the files which may be admitted after Forget, avoids
+claiming that projection deletion removes history, and can invalidate every
+old handle by retiring its store UUID. Its cost is substantial: **all previous
+snapshots for the affected Reader become unavailable**, including references
+to retained records. The preview must disclose this scope. The independent
+Reader keeps its original identity, history, and receipts.
+
+The replacement needs retained record identities and allowed historical
+values, but receives a new store UUID. Migration must record non-content
+lineage without pretending replayed values are the original acceptance events.
+No old receipt is rewritten, no old basis is silently upgraded, and no new
+acceptance is attributed to the Reader without the disclosed migration policy.
+A host may create a new basis after explicit selection of the surviving
+knowledge. A future selective-erasure implementation that preserves unaffected
+snapshots would require a different, thoroughly enforced history contract.
+
+The prototype replays known synthetic surviving rows and one correction through
+public Graft ingestion. It preserves those values, not original batch/revision
+identities or acceptance times. It is not a general migration implementation;
+public reads omit private fields and cannot be used as a lossless export.
+
+## Protocol and recovery
+
+1. Quiesce the affected Reader's writers and runs. Construct a complete preview
+   from a pinned boundary and current dependency inventory; obtain exact
+   action-specific approval.
+2. Durably append the decision to an independent, monotonic host journal.
+   Increment that Reader's Forget epoch and retire its old generation **before**
+   deleting or rebuilding anything. Reads, cache hits, workers, imports, and
+   restores require current journal state and fail closed if it is missing.
+3. Build a replacement in a quarantined directory from allowed authority.
+   Validate survivor history, private fields, schema, relationships, definitions,
+   and provenance. Audit every logical table and derived file for excluded
+   content. Keep the Reader blocked if any validation fails.
+4. Remove inventoried local copies idempotently, verify absence, and record
+   remaining external/offline obligations without payloads. Dispose of failed
+   candidates too. Copy and verify a closed replacement backup before publication.
+5. Atomically publish the certified image and its checksum/identity in the host
+   registry at the current epoch. A read must validate registry identity both
+   before access and before releasing collected results. Reconnects/restore use
+   this same gate. Outstanding external disposal remains visible separately.
+
+A crash after step 2 leaves access blocked. A crash during replacement or
+cleanup resumes the same approved request, without allocating another epoch
+or resurrecting the old store. A crash after publication returns the existing
+result on retry. Reusing the request ID with a different preview is rejected.
+Production needs transactional compare-and-swap, leases/fencing, durable writes,
+and an independent journal disaster-recovery procedure; an in-memory flag or
+an unverified journal restored alongside the old database cannot provide this.
+
+Journal audit data should be limited to opaque Reader/store/request IDs, epoch,
+status, timestamps, approved scope identifiers, and disposal acknowledgments.
+Even IDs can be identifying: choose opaque random IDs, restrict access and
+retention, and avoid excerpts, titles, URLs, raw errors, or payload digests in
+long-lived audit records. Content checksums used to admit a live backup are
+restricted operational metadata, not necessarily permanent audit fields.
+
+## Backup admission and limitations
+
+A backup records exact accepted boundary, store UUID, schema/compiler and
+format versions, Reader binding, epoch, file checksums, and journal watermark.
+The registry certifies the exact image; an attacker or stale worker changing a
+sidecar epoch cannot rehabilitate an old database. An unknown format, mismatched
+UUID/checksum/Reader, missing journal, pending decision, or retired generation
+is refused before it can be served. A verified retained backup restores
+corrections and historical reads exactly before Forget. After Forget, only a
+newly certified replacement backup is admitted.
+
+The initial policy refuses **every** older image, including a pre-Forget backup
+that is otherwise intact. It does not automatically filter and serve the old
+backup, nor silently accept rollback of later corrections. Salvaging surviving
+data from a retired backup is a separate authorized, offline migration through
+the full replacement validator. If no certified new backup exists, service
+stays unavailable until recovery is verified.
+
+The journal must survive independently of the backups it invalidates. Protect
+its monotonic watermark through separate durable replication/backup and trusted
+recovery. If both current journal and external freshness evidence are lost,
+fail closed; checksums cannot prove journal freshness. This proof does not
+establish resistance to a privileged operator rolling back both stores and
+journal, concurrent writers, power loss, or tampered RDS files.
+
+Encrypted offline backups may remain readable to anyone retaining their keys.
+Denying restore into the application is a non-resurrection guarantee, not
+erasure of those bytes. Key destruction helps only with proven per-scope keys
+and complete key-copy retirement; shared backup keys cannot be destroyed
+without affecting other Readers. Report local disposal and offline/external
+retention obligations separately, and do not report permanent Forget complete
+while required copies remain outside the promised retention policy.
+
+DuckDB documents [space reclamation](https://duckdb.org/docs/current/operations_manual/footprint_of_duckdb/reclaiming_space)
+and [checkpointing](https://duckdb.org/docs/current/sql/statements/checkpoint),
+not secure erasure of filesystem/SSD/cloud remnants. Neither SQL deletion,
+`VACUUM`, checkpointing, new-file copying, nor unlinking supplies that guarantee.
+The test copies only closed databases and checks logical absence/file removal.
+
+## Executable evidence and implementation tasks
+
+`tests/testthat/test-forget-restore.R` runs against real synthetic Graft files,
+snapshots, receipts, histories and public reads. Its test-only helper supplies a
+single-writer journal and a known-data replacement builder. Fault hooks exercise
+accepted, validated, partially removed, and published states; a fresh R process
+checks the persisted denial decision. Placeholder files stand in for OKF,
+cache, checkpoint and Conversation disposal obligations. They do **not** prove
+actual OKF/export, Rill, provider, or filesystem erasure behavior. The original
+backup deliberately remains readable through raw file access, but the host
+restore gate refuses it. No real user data is touched.
+
+Bounded follow-through, in dependency order:
+
+1. **Graft replacement migration:** introduce validated value objects for an
+   erasure selection, replacement manifest and migration report. Build a new
+   store from retained authority, including private fields and allowed history;
+   regenerate projections and managed OKF. Reject unsupported schema/provenance
+   cases and verify all original and derived copies. Proposed internal shape:
+   `prepare_replacement(store, selection, destination)` returns a candidate and
+   an audit report. This spelling is illustrative, not an exported API.
+2. **Rill authorization and journal:** own exact preview/approval, historical
+   dependency closure, independent durable journal, fencing, run cancellation,
+   cache invalidation and read/delivery/restore admission. Proposed host shape:
+   `approve_forget(preview)` persists the decision; `resume_forget(request_id)`
+   resumes it. Bind to actual Reader/Document/Agent Run records under #51.
+3. **Storage operations:** implement closed-store bundles, versioned manifests,
+   replacement-backup verification, atomic publication, journal recovery and
+   local/external disposal acknowledgments. Exercise process kills, disk full,
+   competing writers, corrupt/missing files and restoration on a clean host.
+4. **Product acceptance:** verify Conversation deletion versus accepted outcomes,
+   shared private sources, historical dependency changes, actual OKF/Commons and
+   checkpoints, two authenticated Readers, and external retention messaging.
+   Rill rollout stays gated until these production paths pass.
+
+These tasks are the proposed handoff under #48, not completed implementations.
+Review should settle the broad snapshot-retirement tradeoff before any public
+API is added. No contract version or supported Graft behavior changes here.

--- a/adr/0006-retire-forgotten-generations-before-restore.md
+++ b/adr/0006-retire-forgotten-generations-before-restore.md
@@ -170,7 +170,11 @@ The test copies only closed databases and checks logical absence/file removal.
 `tests/testthat/test-forget-restore.R` runs against real synthetic Graft files,
 snapshots, receipts, histories and public reads. Its test-only helper supplies a
 single-writer journal and a known-data replacement builder. Its certifier compares retained logical revisions against the original synthetic
-authority, including private fields, while excluding replay timestamps. Candidate
+authority, including private fields, while excluding replay timestamps. It also
+checks each retained head against the latest logical revision and compares every
+logical table, including metadata, with the image captured by its trusted
+fixed-data builder. Unknown images or later modifications are refused. This
+fixture-specific image comparison is not a general migration sanitizer. Candidate
 paths are registered in the synthetic operational journal before validation so
 rejected or abandoned files and backup sidecars remain cleanup obligations.
 Fault hooks exercise accepted, validated, partially removed, and published states; a fresh R process

--- a/tests/testthat/helper-forget-restore.R
+++ b/tests/testthat/helper-forget-restore.R
@@ -217,6 +217,31 @@ forget_finish <- function(
   invisible(state)
 }
 
+forget_tables <- function(path) {
+  connection <- DBI::dbConnect(duckdb::duckdb(), path, read_only = TRUE)
+  on.exit(DBI::dbDisconnect(connection, shutdown = TRUE))
+  tables <- sort(DBI::dbListTables(connection))
+  stats::setNames(
+    lapply(tables, function(table) {
+      rows <- DBI::dbReadTable(connection, table)
+      keys <- vapply(
+        seq_len(nrow(rows)),
+        function(row) {
+          as.character(jsonlite::toJSON(
+            rows[row, , drop = FALSE],
+            dataframe = "rows"
+          ))
+        },
+        character(1)
+      )
+      rows <- rows[order(keys), , drop = FALSE]
+      rownames(rows) <- NULL
+      rows
+    }),
+    tables
+  )
+}
+
 forget_revisions <- function(path) {
   connection <- DBI::dbConnect(duckdb::duckdb(), path, read_only = TRUE)
   on.exit(DBI::dbDisconnect(connection, shutdown = TRUE))
@@ -243,7 +268,8 @@ forget_fixture <- function(.local_envir = parent.frame()) {
   correction$body <- "PRIVATE-FORGET-CORRECTED"
   survivor <- records$knowledge[1L, , drop = FALSE]
   survivor$body <- "Retained accepted correction."
-  build <- function(name, remove = character()) {
+  images <- new.env(parent = emptyenv())
+  create <- function(name, remove) {
     path <- file.path(directory, paste0(name, ".duckdb"))
     store <- graft_open(
       graft_schema(system.file(
@@ -275,6 +301,13 @@ forget_fixture <- function(.local_envir = parent.frame()) {
     }
     list(path = path, original = original)
   }
+  build <- function(name, remove = character()) {
+    candidate <- create(name, remove)
+    # Only this trusted, fixed-data builder establishes allowed logical images.
+    # This is not a validator for arbitrary externally supplied migrations.
+    images[[candidate$path]] <- forget_tables(candidate$path)
+    candidate
+  }
   certify <- function(path, preview) {
     expected <- lapply(records, function(table) {
       table[!table$id %in% preview$ids, , drop = FALSE]
@@ -285,6 +318,27 @@ forget_fixture <- function(.local_envir = parent.frame()) {
     ))
     connection <- DBI::dbConnect(duckdb::duckdb(), path, read_only = TRUE)
     on.exit(DBI::dbDisconnect(connection, shutdown = TRUE))
+    retained <- authority[!authority$record_id %in% preview$ids, , drop = FALSE]
+    rownames(retained) <- NULL
+    latest <- retained[
+      !duplicated(retained$record_id, fromLast = TRUE),
+      c("record_id", "class", "revision_number"),
+      drop = FALSE
+    ]
+    rownames(latest) <- NULL
+    heads <- DBI::dbGetQuery(
+      connection,
+      paste(
+        "SELECT h.record_id, r.class, r.revision_number",
+        "FROM _graft_record_heads h LEFT JOIN _graft_record_revisions r",
+        "ON h.revision_id = r.revision_id AND h.record_id = r.record_id",
+        "AND h.class = r.class AND h.revision_number = r.revision_number",
+        "ORDER BY h.record_id"
+      )
+    )
+    if (!identical(heads, latest)) {
+      return(FALSE)
+    }
     # Test-only raw inspection includes fields omitted by public reads.
     ids <- DBI::dbGetQuery(
       connection,
@@ -306,9 +360,9 @@ forget_fixture <- function(.local_envir = parent.frame()) {
     ) {
       return(FALSE)
     }
-    retained <- authority[!authority$record_id %in% preview$ids, , drop = FALSE]
-    rownames(retained) <- NULL
-    identical(forget_revisions(path), retained)
+    identical(forget_revisions(path), retained) &&
+      !is.null(images[[path]]) &&
+      identical(forget_tables(path), images[[path]])
   }
   alice <- build("alice")
   authority <- forget_revisions(alice$path)

--- a/tests/testthat/helper-forget-restore.R
+++ b/tests/testthat/helper-forget-restore.R
@@ -1,0 +1,305 @@
+# Synthetic protocol model only: one writer, closed stores, trusted local files.
+# These helpers are not a production purge, backup, or authorization API.
+forget_error <- function(class = "forget_unavailable") {
+  stop(structure(
+    list(message = "Knowledge generation is unavailable.", call = NULL),
+    class = c(class, "error", "condition")
+  ))
+}
+
+forget_journal_read <- function(journal) {
+  files <- sort(list.files(
+    journal,
+    pattern = "^event-[0-9]+[.]rds$",
+    full.names = TRUE
+  ))
+  if (length(files) == 0L) {
+    forget_error()
+  }
+  readRDS(tail(files, 1L))
+}
+
+forget_journal_write <- function(journal, state) {
+  files <- list.files(journal, pattern = "^event-[0-9]+[.]rds$")
+  destination <- file.path(
+    journal,
+    sprintf("event-%06d.rds", length(files) + 1L)
+  )
+  temporary <- tempfile("pending-", tmpdir = journal)
+  on.exit(unlink(temporary))
+  saveRDS(state, temporary)
+  if (!file.rename(temporary, destination)) {
+    forget_error()
+  }
+  invisible(state)
+}
+
+forget_fingerprint <- function(path) {
+  if (!file.exists(path)) {
+    forget_error()
+  }
+  digest::digest(file = path, algo = "sha256")
+}
+
+forget_open <- function(path, read) {
+  store <- graft_open(
+    graft_schema(system.file(
+      "extdata/narrative-knowledge.data-dict.json",
+      package = "graft"
+    )),
+    path,
+    read_only = TRUE,
+    okf = "disabled"
+  )
+  on.exit(graft_close(store))
+  read(store)
+}
+
+forget_manifest <- function(path, reader, epoch) {
+  list(
+    format = 1L,
+    reader = reader,
+    epoch = epoch,
+    snapshot = forget_open(path, \(store) S7::props(graft_snapshot(store))),
+    checksum = forget_fingerprint(path)
+  )
+}
+
+# The host journal admits only the exact certified image; changing an epoch in
+# a backup sidecar cannot turn an old database into a sanitized generation.
+forget_read <- function(journal, path, manifest, read) {
+  state <- forget_journal_read(journal)
+  if (
+    !identical(state$status, "active") ||
+      !identical(manifest, state$manifest) ||
+      !identical(manifest$format, 1L) ||
+      !identical(forget_fingerprint(path), manifest$checksum)
+  ) {
+    forget_error()
+  }
+  value <- forget_open(path, function(store) {
+    if (!identical(S7::props(graft_snapshot(store)), manifest$snapshot)) {
+      forget_error()
+    }
+    read(store)
+  })
+  if (!identical(forget_journal_read(journal), state)) {
+    forget_error()
+  }
+  value
+}
+
+# This schema-specific dependency closure belongs to the synthetic host.
+# Incoming private derivatives are removed; an outward source survives while
+# another retained artifact references it. Forgetting the source cascades inward.
+forget_selection <- function(records, roots) {
+  all_ids <- unlist(lapply(records, `[[`, "id"), use.names = FALSE)
+  if (!length(roots) || !all(roots %in% all_ids)) {
+    forget_error()
+  }
+  selected <- roots
+  repeat {
+    before <- selected
+    links <- records$support
+    source_dependents <- links$knowledge_id[links$source_id %in% selected]
+    selected <- union(selected, source_dependents)
+    selected <- union(
+      selected,
+      links$id[
+        links$knowledge_id %in% selected | links$source_id %in% selected
+      ]
+    )
+    used_before <- unique(links$source_id[links$id %in% selected])
+    used_after <- unique(links$source_id[!links$id %in% selected])
+    selected <- union(selected, setdiff(used_before, used_after))
+    if (identical(before, selected)) break
+  }
+  sort(selected)
+}
+
+forget_preview <- function(journal, records, roots, request) {
+  state <- forget_journal_read(journal)
+  if (!identical(state$status, "active")) {
+    forget_error()
+  }
+  list(
+    action = "forget",
+    request = request,
+    reader = state$manifest$reader,
+    prior = state$manifest,
+    ids = forget_selection(records, roots)
+  )
+}
+
+forget_accept <- function(journal, preview, authorize) {
+  state <- forget_journal_read(journal)
+  if (identical(state$request, preview$request)) {
+    if (!identical(state$preview, preview)) {
+      forget_error()
+    }
+    return(invisible(state))
+  }
+  if (
+    !identical(preview$action, "forget") ||
+      !identical(state$status, "active") ||
+      !identical(preview$prior, state$manifest) ||
+      !isTRUE(authorize(preview))
+  ) {
+    forget_error("forget_not_authorized")
+  }
+  state$status <- "blocked"
+  state$request <- preview$request
+  state$preview <- preview
+  state$epoch <- state$manifest$epoch + 1L
+  state$manifest <- NULL
+  forget_journal_write(journal, state)
+}
+
+# Fault hooks model process interruption between durable protocol steps.
+forget_finish <- function(
+  journal,
+  candidate,
+  purge_paths,
+  certify,
+  interrupt = identity
+) {
+  state <- forget_journal_read(journal)
+  if (identical(state$status, "active")) {
+    return(invisible(state))
+  }
+  manifest <- forget_manifest(candidate, state$preview$reader, state$epoch)
+  if (
+    identical(manifest$snapshot$store_id, state$preview$prior$snapshot$store_id)
+  ) {
+    forget_error()
+  }
+  if (!isTRUE(certify(candidate, state$preview))) {
+    forget_error()
+  }
+  backup <- paste0(candidate, ".backup")
+  if (!file.exists(backup) && !file.copy(candidate, backup)) {
+    forget_error()
+  }
+  if (!identical(forget_fingerprint(backup), manifest$checksum)) {
+    forget_error()
+  }
+  interrupt("candidate_validated")
+  for (path in purge_paths) {
+    unlink(path, recursive = TRUE)
+    if (file.exists(path)) {
+      forget_error()
+    }
+    interrupt("copy_removed")
+  }
+  state$manifest <- manifest
+  state$status <- "active"
+  state$completion <- "local copies removed; offline backup retained and denied"
+  forget_journal_write(journal, state)
+  interrupt("published")
+  invisible(state)
+}
+
+forget_fixture <- function(.local_envir = parent.frame()) {
+  directory <- withr::local_tempdir(.local_envir = .local_envir)
+  records <- narrative_fixture()$narrative_records()
+  records$knowledge$body[2L] <- "PRIVATE-FORGET-ORIGINAL"
+  correction <- records$knowledge[2L, , drop = FALSE]
+  correction$body <- "PRIVATE-FORGET-CORRECTED"
+  survivor <- records$knowledge[1L, , drop = FALSE]
+  survivor$body <- "Retained accepted correction."
+  build <- function(name, remove = character()) {
+    path <- file.path(directory, paste0(name, ".duckdb"))
+    store <- graft_open(
+      graft_schema(system.file(
+        "extdata/narrative-knowledge.data-dict.json",
+        package = "graft"
+      )),
+      path,
+      okf = "disabled"
+    )
+    on.exit(graft_close(store))
+    selected <- lapply(records, function(table) {
+      table[!table$id %in% remove, , drop = FALSE]
+    })
+    selected <- selected[vapply(selected, nrow, integer(1)) > 0L]
+    graft_ingest(
+      store,
+      selected,
+      graft_provenance("synthetic-host", idempotency_key = "seed")
+    )
+    original <- graft_snapshot(store)
+    for (value in list(correction, survivor)) {
+      if (!value$id %in% remove) {
+        graft_ingest(
+          store,
+          list(knowledge = value),
+          graft_provenance("synthetic-host")
+        )
+      }
+    }
+    list(path = path, original = original)
+  }
+  certify <- function(path, preview) {
+    expected <- lapply(records, function(table) {
+      table[!table$id %in% preview$ids, , drop = FALSE]
+    })
+    expected_ids <- sort(unlist(
+      lapply(expected, `[[`, "id"),
+      use.names = FALSE
+    ))
+    connection <- DBI::dbConnect(duckdb::duckdb(), path, read_only = TRUE)
+    on.exit(DBI::dbDisconnect(connection, shutdown = TRUE))
+    # Test-only raw inspection includes fields omitted by public reads.
+    ids <- DBI::dbGetQuery(
+      connection,
+      "SELECT record_id FROM _graft_record_heads"
+    )$record_id
+    if (!identical(sort(ids), expected_ids)) {
+      return(FALSE)
+    }
+    tables <- lapply(DBI::dbListTables(connection), \(table) {
+      DBI::dbReadTable(connection, table)
+    })
+    encoded <- jsonlite::toJSON(tables, auto_unbox = TRUE)
+    if (
+      any(vapply(
+        preview$ids,
+        \(id) grepl(id, encoded, fixed = TRUE),
+        logical(1)
+      ))
+    ) {
+      return(FALSE)
+    }
+    TRUE
+  }
+  alice <- build("alice")
+  bob <- build("bob")
+  journal <- file.path(directory, "independent-journal")
+  dir.create(journal)
+  manifest <- forget_manifest(alice$path, "alice", 0L)
+  forget_journal_write(journal, list(status = "active", manifest = manifest))
+  backup <- file.path(directory, "offline-backup.duckdb")
+  if (!file.copy(alice$path, backup)) {
+    forget_error()
+  }
+  copies <- file.path(
+    directory,
+    c("managed-okf", "query-cache", "reuse-checkpoint", "conversation")
+  )
+  for (path in copies) {
+    writeLines("PRIVATE-FORGET-CORRECTED", path)
+  }
+  list(
+    directory = directory,
+    certify = certify,
+    records = records,
+    build = build,
+    alice = alice,
+    bob = bob,
+    journal = journal,
+    manifest = manifest,
+    backup = backup,
+    copies = copies,
+    purge_paths = c(alice$path, copies)
+  )
+}

--- a/tests/testthat/helper-forget-restore.R
+++ b/tests/testthat/helper-forget-restore.R
@@ -167,6 +167,21 @@ forget_finish <- function(
   if (identical(state$status, "active")) {
     return(invisible(state))
   }
+  if (candidate %in% purge_paths) {
+    forget_error()
+  }
+  backup <- paste0(candidate, ".backup")
+  state$candidates <- union(
+    state$candidates,
+    c(candidate, backup, paste0(candidate, ".wal"))
+  )
+  forget_journal_write(journal, state)
+  accepted <- FALSE
+  on.exit({
+    if (!accepted) {
+      unlink(c(candidate, backup, paste0(candidate, ".wal")), recursive = TRUE)
+    }
+  })
   manifest <- forget_manifest(candidate, state$preview$reader, state$epoch)
   if (
     identical(manifest$snapshot$store_id, state$preview$prior$snapshot$store_id)
@@ -176,15 +191,18 @@ forget_finish <- function(
   if (!isTRUE(certify(candidate, state$preview))) {
     forget_error()
   }
-  backup <- paste0(candidate, ".backup")
   if (!file.exists(backup) && !file.copy(candidate, backup)) {
     forget_error()
   }
   if (!identical(forget_fingerprint(backup), manifest$checksum)) {
     forget_error()
   }
+  accepted <- TRUE
   interrupt("candidate_validated")
-  for (path in purge_paths) {
+  for (path in union(
+    purge_paths,
+    setdiff(state$candidates, c(candidate, backup))
+  )) {
     unlink(path, recursive = TRUE)
     if (file.exists(path)) {
       forget_error()
@@ -197,6 +215,24 @@ forget_finish <- function(
   forget_journal_write(journal, state)
   interrupt("published")
   invisible(state)
+}
+
+forget_revisions <- function(path) {
+  connection <- DBI::dbConnect(duckdb::duckdb(), path, read_only = TRUE)
+  on.exit(DBI::dbDisconnect(connection, shutdown = TRUE))
+  revisions <- DBI::dbGetQuery(
+    connection,
+    paste(
+      "SELECT record_id, class, revision_number, operation, payload_json",
+      "FROM _graft_record_revisions ORDER BY record_id, revision_number"
+    )
+  )
+  revisions$payload_json <- lapply(revisions$payload_json, function(payload) {
+    value <- jsonlite::fromJSON(payload, simplifyVector = FALSE)
+    value[c("created_at", "updated_at")] <- NULL
+    value
+  })
+  revisions
 }
 
 forget_fixture <- function(.local_envir = parent.frame()) {
@@ -270,9 +306,12 @@ forget_fixture <- function(.local_envir = parent.frame()) {
     ) {
       return(FALSE)
     }
-    TRUE
+    retained <- authority[!authority$record_id %in% preview$ids, , drop = FALSE]
+    rownames(retained) <- NULL
+    identical(forget_revisions(path), retained)
   }
   alice <- build("alice")
+  authority <- forget_revisions(alice$path)
   bob <- build("bob")
   journal <- file.path(directory, "independent-journal")
   dir.create(journal)

--- a/tests/testthat/test-forget-restore.R
+++ b/tests/testthat/test-forget-restore.R
@@ -328,7 +328,10 @@ test_that("a fresh worker and an in-flight read honor the current Forget decisio
   expect_identical(result, "not released")
   helper <- normalizePath(test_path("helper-forget-restore.R"))
   outcome <- callr::r(
-    function(helper, journal, backup, manifest) {
+    function(helper, journal, backup, manifest, checkout) {
+      if (!is.null(checkout)) {
+        pkgload::load_all(checkout, quiet = TRUE)
+      }
       library(graft)
       source(helper, local = TRUE)
       tryCatch(
@@ -336,7 +339,17 @@ test_that("a fresh worker and an in-flight read honor the current Forget decisio
         error = \(error) class(error)[1L]
       )
     },
-    args = list(helper, fixture$journal, fixture$backup, fixture$manifest)
+    args = list(
+      helper,
+      fixture$journal,
+      fixture$backup,
+      fixture$manifest,
+      checkout = if (pkgload::is_dev_package("graft")) {
+        normalizePath(test_path("../.."))
+      } else {
+        NULL
+      }
+    )
   )
   expect_identical(outcome, "forget_unavailable")
 })
@@ -382,4 +395,120 @@ test_that("uncertified replacements and corrupt replacement backups keep access 
     ),
     class = "forget_unavailable"
   )
+})
+
+test_that("rejected and abandoned candidates are disposed before successful retry", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  forget_accept(fixture$journal, preview, \(plan) identical(plan, preview))
+  rejected <- fixture$build("rejected")
+  expect_identical(
+    file.copy(rejected$path, paste0(rejected$path, ".backup")),
+    TRUE
+  )
+  expect_error(
+    forget_finish(
+      fixture$journal,
+      rejected$path,
+      fixture$purge_paths,
+      fixture$certify
+    ),
+    class = "forget_unavailable"
+  )
+  expect_identical(
+    file.exists(c(rejected$path, paste0(rejected$path, ".backup"))),
+    c(FALSE, FALSE)
+  )
+  abandoned <- fixture$build("abandoned", preview$ids)
+  expect_error(
+    forget_finish(
+      fixture$journal,
+      abandoned$path,
+      fixture$purge_paths,
+      fixture$certify,
+      \(point) forget_error("synthetic_crash")
+    ),
+    class = "synthetic_crash"
+  )
+  candidate <- fixture$build("replacement", preview$ids)
+  forget_finish(
+    fixture$journal,
+    candidate$path,
+    fixture$purge_paths,
+    fixture$certify
+  )
+  expect_identical(
+    file.exists(c(
+      rejected$path,
+      abandoned$path,
+      paste0(abandoned$path, ".backup")
+    )),
+    rep(FALSE, 3L)
+  )
+  expect_identical(forget_journal_read(fixture$journal)$status, "active")
+})
+
+test_that("same-head candidates cannot lose or alter retained revisions", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  forget_accept(fixture$journal, preview, \(plan) identical(plan, preview))
+  for (mutation in c("missing", "changed", "private")) {
+    candidate <- fixture$build(mutation, preview$ids)
+    connection <- DBI::dbConnect(duckdb::duckdb(), candidate$path)
+    if (mutation == "missing") {
+      DBI::dbExecute(
+        connection,
+        "DELETE FROM _graft_record_revisions WHERE record_id = 'knowledge:conclusion' AND revision_number = 1"
+      )
+    } else {
+      old <- DBI::dbGetQuery(
+        connection,
+        "SELECT payload_json FROM _graft_record_revisions WHERE record_id = 'knowledge:conclusion' AND revision_number = 1"
+      )$payload_json
+      payload <- jsonlite::fromJSON(old, simplifyVector = FALSE)
+      payload[[
+        if (mutation == "private") "owner_binding" else "body"
+      ]] <- "corrupted survivor"
+      DBI::dbExecute(
+        connection,
+        "UPDATE _graft_record_revisions SET payload_json = ? WHERE record_id = 'knowledge:conclusion' AND revision_number = 1",
+        params = list(as.character(jsonlite::toJSON(
+          payload,
+          auto_unbox = TRUE,
+          null = "null"
+        )))
+      )
+    }
+    DBI::dbDisconnect(connection, shutdown = TRUE)
+    expect_identical(fixture$certify(candidate$path, preview), FALSE)
+    expect_error(
+      forget_finish(
+        fixture$journal,
+        candidate$path,
+        fixture$purge_paths,
+        fixture$certify
+      ),
+      class = "forget_unavailable"
+    )
+    expect_identical(forget_journal_read(fixture$journal)$status, "blocked")
+  }
+  candidate <- fixture$build("replacement", preview$ids)
+  expect_identical(fixture$certify(candidate$path, preview), TRUE)
+  forget_finish(
+    fixture$journal,
+    candidate$path,
+    fixture$purge_paths,
+    fixture$certify
+  )
+  expect_identical(forget_journal_read(fixture$journal)$status, "active")
 })

--- a/tests/testthat/test-forget-restore.R
+++ b/tests/testthat/test-forget-restore.R
@@ -238,6 +238,7 @@ test_that("crashes and cleanup retries cannot reopen a retired generation", {
       grepl("PRIVATE-FORGET", canonical_json(tables), fixed = TRUE),
       FALSE
     )
+    unlink(fixture$directory, recursive = TRUE)
   }
 })
 
@@ -511,4 +512,89 @@ test_that("same-head candidates cannot lose or alter retained revisions", {
     fixture$certify
   )
   expect_identical(forget_journal_read(fixture$journal)$status, "active")
+})
+
+test_that("forgotten payloads in metadata cannot enter a certified image", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  forget_accept(fixture$journal, preview, \(plan) identical(plan, preview))
+  for (field in c("metadata_json", "producer")) {
+    candidate <- fixture$build(field, preview$ids)
+    connection <- DBI::dbConnect(duckdb::duckdb(), candidate$path)
+    DBI::dbExecute(
+      connection,
+      paste0("UPDATE _graft_batches SET ", field, " = ?"),
+      params = list(
+        if (field == "metadata_json") {
+          '{"copy":"PRIVATE-FORGET-CORRECTED"}'
+        } else {
+          "PRIVATE-FORGET-CORRECTED"
+        }
+      )
+    )
+    DBI::dbDisconnect(connection, shutdown = TRUE)
+    expect_identical(fixture$certify(candidate$path, preview), FALSE)
+    expect_error(
+      forget_finish(
+        fixture$journal,
+        candidate$path,
+        fixture$purge_paths,
+        fixture$certify
+      ),
+      class = "forget_unavailable"
+    )
+    expect_identical(forget_journal_read(fixture$journal)$status, "blocked")
+  }
+})
+
+test_that("a stale head with rebuilt projections is refused before publication", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  forget_accept(fixture$journal, preview, \(plan) identical(plan, preview))
+  candidate <- fixture$build("stale-head", preview$ids)
+  connection <- DBI::dbConnect(duckdb::duckdb(), candidate$path)
+  DBI::dbExecute(
+    connection,
+    paste(
+      "UPDATE _graft_record_heads SET revision_id =",
+      "(SELECT revision_id FROM _graft_record_revisions WHERE record_id = 'knowledge:conclusion' AND revision_number = 1),",
+      "revision_number = 1 WHERE record_id = 'knowledge:conclusion'"
+    )
+  )
+  schema <- as_graft_schema_internal(
+    graft_schema(system.file(
+      "extdata/narrative-knowledge.data-dict.json",
+      package = "graft"
+    )),
+    "schema"
+  )
+  rebuild_projection_views(connection, schema)
+  DBI::dbDisconnect(connection, shutdown = TRUE)
+  expect_error(
+    forget_open(candidate$path, \(store) {
+      graft_get(store, "knowledge:conclusion")
+    }),
+    class = "graft_backend_error"
+  )
+  expect_identical(fixture$certify(candidate$path, preview), FALSE)
+  expect_error(
+    forget_finish(
+      fixture$journal,
+      candidate$path,
+      fixture$purge_paths,
+      fixture$certify
+    ),
+    class = "forget_unavailable"
+  )
+  expect_identical(forget_journal_read(fixture$journal)$status, "blocked")
 })

--- a/tests/testthat/test-forget-restore.R
+++ b/tests/testthat/test-forget-restore.R
@@ -1,0 +1,385 @@
+test_that("a closed-store backup restores accepted corrections and pinned history", {
+  fixture <- forget_fixture()
+  expected <- forget_read(
+    fixture$journal,
+    fixture$alice$path,
+    fixture$manifest,
+    function(store) {
+      list(
+        current = graft_get(store, "knowledge:interpretation"),
+        old = graft_get(
+          graft_at(store, fixture$alice$original),
+          "knowledge:interpretation"
+        ),
+        history = graft_history(store, "knowledge:interpretation")
+      )
+    }
+  )
+  restored <- forget_read(
+    fixture$journal,
+    fixture$backup,
+    fixture$manifest,
+    function(store) {
+      list(
+        current = graft_get(store, "knowledge:interpretation"),
+        old = graft_get(
+          graft_at(store, fixture$alice$original),
+          "knowledge:interpretation"
+        ),
+        history = graft_history(store, "knowledge:interpretation")
+      )
+    }
+  )
+  expect_identical(restored, expected)
+  expect_identical(restored$current$record$body, "PRIVATE-FORGET-CORRECTED")
+  expect_identical(restored$old$record$body, "PRIVATE-FORGET-ORIGINAL")
+  expect_equal(nrow(restored$history), 2L)
+})
+
+test_that("the host previews dependent copies while retaining a still-used source", {
+  fixture <- forget_fixture()
+  selected <- forget_selection(fixture$records, "knowledge:interpretation")
+  expect_identical(
+    selected,
+    c("knowledge:interpretation", "support:interpretation")
+  )
+  expect_identical(
+    forget_selection(fixture$records, "source:trial-v1"),
+    sort(c(
+      "knowledge:conclusion",
+      "knowledge:interpretation",
+      "source:trial-v1",
+      "support:conclusion",
+      "support:interpretation"
+    ))
+  )
+  expect_identical(
+    forget_selection(
+      fixture$records,
+      c("knowledge:conclusion", "knowledge:interpretation")
+    ),
+    forget_selection(fixture$records, "source:trial-v1")
+  )
+  unlink(fixture$copies[4L])
+  expect_identical(
+    forget_open(fixture$alice$path, function(store) {
+      graft_get(store, "knowledge:interpretation")$record$body
+    }),
+    "PRIVATE-FORGET-CORRECTED"
+  )
+})
+
+test_that("Forget requires exact action approval and retries preserve the decision", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  before <- forget_journal_read(fixture$journal)
+  expect_error(
+    forget_accept(fixture$journal, preview, \(plan) FALSE),
+    class = "forget_not_authorized"
+  )
+  wrong <- preview
+  wrong$action <- "archive"
+  expect_error(
+    forget_accept(fixture$journal, wrong, \(plan) TRUE),
+    class = "forget_not_authorized"
+  )
+  expect_identical(forget_journal_read(fixture$journal), before)
+  forget_accept(fixture$journal, preview, \(plan) identical(plan, preview))
+  accepted <- forget_journal_read(fixture$journal)
+  expect_identical(accepted$epoch, 1L)
+  forget_accept(fixture$journal, preview, \(plan) FALSE)
+  expect_identical(forget_journal_read(fixture$journal), accepted)
+  wrong <- preview
+  wrong$ids <- "knowledge:preference"
+  expect_error(
+    forget_accept(fixture$journal, wrong, \(plan) TRUE),
+    class = "forget_unavailable"
+  )
+  expect_error(
+    forget_read(
+      fixture$journal,
+      fixture$backup,
+      fixture$manifest,
+      graft_snapshot
+    ),
+    class = "forget_unavailable"
+  )
+})
+
+test_that("an approval tied to a superseded backup boundary is refused", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  state <- forget_journal_read(fixture$journal)
+  state$manifest$epoch <- 1L
+  forget_journal_write(fixture$journal, state)
+  expect_error(
+    forget_accept(fixture$journal, preview, \(plan) TRUE),
+    class = "forget_not_authorized"
+  )
+})
+
+test_that("crashes and cleanup retries cannot reopen a retired generation", {
+  for (stage in c(
+    "accepted",
+    "candidate_validated",
+    "copy_removed",
+    "published"
+  )) {
+    fixture <- forget_fixture()
+    bob_before <- forget_open(fixture$bob$path, function(store) {
+      graft_get(store, "knowledge:interpretation")
+    })
+    preview <- forget_preview(
+      fixture$journal,
+      fixture$records,
+      "knowledge:interpretation",
+      "request-1"
+    )
+    forget_accept(fixture$journal, preview, \(plan) identical(plan, preview))
+    candidate <- fixture$build("replacement", preview$ids)
+    if (stage != "accepted") {
+      expect_error(
+        forget_finish(
+          fixture$journal,
+          candidate$path,
+          fixture$purge_paths,
+          fixture$certify,
+          function(point) {
+            if (point == stage) forget_error("synthetic_crash")
+          }
+        ),
+        class = "synthetic_crash"
+      )
+    }
+    expect_error(
+      forget_read(
+        fixture$journal,
+        fixture$backup,
+        fixture$manifest,
+        graft_snapshot
+      ),
+      class = "forget_unavailable"
+    )
+    forget_finish(
+      fixture$journal,
+      candidate$path,
+      fixture$purge_paths,
+      fixture$certify
+    )
+    state <- forget_journal_read(fixture$journal)
+    forget_finish(
+      fixture$journal,
+      candidate$path,
+      fixture$purge_paths,
+      fixture$certify
+    )
+    expect_identical(forget_journal_read(fixture$journal), state)
+    expect_identical(
+      file.exists(fixture$purge_paths),
+      rep(FALSE, length(fixture$purge_paths))
+    )
+    expect_identical(file.exists(fixture$backup), TRUE)
+    retained <- forget_read(
+      fixture$journal,
+      candidate$path,
+      state$manifest,
+      function(store) {
+        list(
+          record = graft_get(store, "knowledge:conclusion"),
+          source = graft_get(store, "source:trial-v1"),
+          history = graft_history(store, "knowledge:conclusion"),
+          search = graft_find(store, "PRIVATE-FORGET")
+        )
+      }
+    )
+    expect_identical(
+      retained$record$record$body,
+      "Retained accepted correction."
+    )
+    expect_identical(
+      retained$source$record$document_revision,
+      "document:synthetic-trial:version-1"
+    )
+    expect_equal(nrow(retained$history), 2L)
+    expect_equal(nrow(retained$search), 0L)
+    expect_error(
+      forget_read(fixture$journal, candidate$path, state$manifest, \(store) {
+        graft_at(store, fixture$alice$original)
+      }),
+      class = "graft_snapshot_store_mismatch"
+    )
+    expect_identical(
+      forget_open(fixture$bob$path, function(store) {
+        graft_get(store, "knowledge:interpretation")
+      }),
+      bob_before
+    )
+    # Inspect every logical table, including private revisions and projections.
+    connection <- DBI::dbConnect(
+      duckdb::duckdb(),
+      candidate$path,
+      read_only = TRUE
+    )
+    tables <- lapply(DBI::dbListTables(connection), \(table) {
+      DBI::dbReadTable(connection, table)
+    })
+    DBI::dbDisconnect(connection, shutdown = TRUE)
+    expect_identical(
+      grepl("PRIVATE-FORGET", canonical_json(tables), fixed = TRUE),
+      FALSE
+    )
+  }
+})
+
+test_that("restore requires the independent ledger and the certified image", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  forget_accept(fixture$journal, preview, \(plan) identical(plan, preview))
+  candidate <- fixture$build("replacement", preview$ids)
+  forget_finish(
+    fixture$journal,
+    candidate$path,
+    fixture$purge_paths,
+    fixture$certify
+  )
+  state <- forget_journal_read(fixture$journal)
+  expect_error(
+    forget_read(
+      fixture$journal,
+      fixture$backup,
+      state$manifest,
+      graft_snapshot
+    ),
+    class = "forget_unavailable"
+  )
+  relabeled <- fixture$manifest
+  relabeled$epoch <- 1L
+  expect_error(
+    forget_read(fixture$journal, fixture$backup, relabeled, graft_snapshot),
+    class = "forget_unavailable"
+  )
+  expect_error(
+    forget_read(
+      fixture$journal,
+      fixture$bob$path,
+      state$manifest,
+      graft_snapshot
+    ),
+    class = "forget_unavailable"
+  )
+  fresh_backup <- file.path(fixture$directory, "fresh-backup.duckdb")
+  expect_identical(file.copy(candidate$path, fresh_backup), TRUE)
+  expect_identical(
+    forget_read(fixture$journal, fresh_backup, state$manifest, \(store) {
+      S7::props(graft_snapshot(store))
+    }),
+    state$manifest$snapshot
+  )
+  expect_identical(
+    grepl("PRIVATE-FORGET", canonical_json(state), fixed = TRUE),
+    FALSE
+  )
+  missing <- file.path(fixture$directory, "missing-journal")
+  expect_error(
+    forget_read(missing, fresh_backup, state$manifest, graft_snapshot),
+    class = "forget_unavailable"
+  )
+})
+
+test_that("a fresh worker and an in-flight read honor the current Forget decision", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  result <- "not released"
+  expect_error(
+    result <- forget_read(
+      fixture$journal,
+      fixture$backup,
+      fixture$manifest,
+      function(store) {
+        value <- graft_get(store, "knowledge:interpretation")
+        forget_accept(fixture$journal, preview, \(plan) {
+          identical(plan, preview)
+        })
+        value
+      }
+    ),
+    class = "forget_unavailable"
+  )
+  expect_identical(result, "not released")
+  helper <- normalizePath(test_path("helper-forget-restore.R"))
+  outcome <- callr::r(
+    function(helper, journal, backup, manifest) {
+      library(graft)
+      source(helper, local = TRUE)
+      tryCatch(
+        forget_read(journal, backup, manifest, graft_snapshot),
+        error = \(error) class(error)[1L]
+      )
+    },
+    args = list(helper, fixture$journal, fixture$backup, fixture$manifest)
+  )
+  expect_identical(outcome, "forget_unavailable")
+})
+
+test_that("uncertified replacements and corrupt replacement backups keep access blocked", {
+  fixture <- forget_fixture()
+  preview <- forget_preview(
+    fixture$journal,
+    fixture$records,
+    "knowledge:interpretation",
+    "request-1"
+  )
+  forget_accept(fixture$journal, preview, \(plan) identical(plan, preview))
+  contaminated <- fixture$build("contaminated")
+  expect_error(
+    forget_finish(
+      fixture$journal,
+      contaminated$path,
+      fixture$purge_paths,
+      fixture$certify
+    ),
+    class = "forget_unavailable"
+  )
+  candidate <- fixture$build("replacement", preview$ids)
+  writeLines("incomplete backup", paste0(candidate$path, ".backup"))
+  expect_error(
+    forget_finish(
+      fixture$journal,
+      candidate$path,
+      fixture$purge_paths,
+      fixture$certify
+    ),
+    class = "forget_unavailable"
+  )
+  expect_identical(forget_journal_read(fixture$journal)$status, "blocked")
+  expect_identical(file.exists(fixture$alice$path), TRUE)
+  expect_error(
+    forget_read(
+      fixture$journal,
+      fixture$backup,
+      fixture$manifest,
+      graft_snapshot
+    ),
+    class = "forget_unavailable"
+  )
+})

--- a/vignettes/forget-restore.Rmd
+++ b/vignettes/forget-restore.Rmd
@@ -1,0 +1,73 @@
+---
+title: "Design Forget and backup recovery"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Design Forget and backup recovery}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+Permanent Forget must remove private content from accepted history and its
+derived copies, while preventing an older backup from bringing it back. Graft
+currently has no supported purge or backup/restore API. The
+[proposed design](https://github.com/JamesHWade/graft/blob/main/adr/0006-retire-forgotten-generations-before-restore.md)
+and [offline protocol tests](https://github.com/JamesHWade/graft/blob/main/tests/testthat/test-forget-restore.R)
+make that gap explicit for [#48](https://github.com/JamesHWade/graft/issues/48).
+They do not clear Rill's production gate.
+
+## Keep the decision outside the backup
+
+Suppose a Reader corrects an accepted interpretation and then chooses Forget.
+A backup made after the correction still contains both original and corrected
+revisions. Restoring it without consulting the current Forget decision would
+make the forgotten interpretation readable again.
+
+The proposal uses a separate host journal to retire the affected Reader's
+store generation before cleanup starts. Access remains blocked while a
+replacement is built and verified. Only a replacement image certified at the
+current Forget epoch may be served or restored. A stale database cannot become
+valid merely by changing its backup's epoch field.
+
+| Recovery point | Proposed behavior |
+| --- | --- |
+| Before Forget | A verified closed-store backup restores exact accepted corrections, pinned history and receipts. |
+| After the decision, before cleanup | Reads and restores remain blocked, including from a fresh worker. |
+| During interrupted cleanup | Retry the same approved request; never reactivate the retired store. |
+| After replacement publication | Read surviving knowledge from the new store UUID; reject every old snapshot and backup for that Reader. |
+| Missing current journal | Refuse recovery until independent freshness evidence is restored. |
+
+## Preview the historical cost
+
+Retiring the whole generation invalidates **all earlier snapshots for the
+affected Reader**, including references to retained records. The proposal
+requires this to appear in the action preview. Surviving values and allowed
+history move to a new store identity; old receipts are not rewritten and old
+reuse bases do not silently acquire different evidence. The second Reader's
+store, snapshots and content survive unchanged.
+
+Dependency scope belongs to the host. In the synthetic fixture, forgetting one
+interpretation removes its support link but retains a source still used by
+another accepted conclusion. Forgetting the source removes both dependent
+outcomes. Real applications must also trace old links and copied passages.
+Deleting a Conversation alone must leave separately accepted Reader Memory and
+Reading Artifacts intact.
+
+## What the proof establishes
+
+The offline tests use real Graft stores to compare original and corrected
+history, rebuild known surviving rows, inspect logical revision/projection
+content, and reject old backups through the proposed host gate. They exercise
+interruption and retries, exact action approval, a fresh worker, modified backup
+metadata, and a read whose result must be withheld after Forget is accepted.
+
+The journal and replacement builder are test fixtures, not production APIs.
+The builder replays known synthetic values and gives them new acceptance
+metadata. Local stand-in files represent cache, OKF, checkpoint and Conversation
+cleanup; actual product integrations remain implementation work.
+
+The retained offline backup still contains the original bytes. Restore denial
+prevents the application from serving them; it is not physical erasure. Complete
+Forget also needs tracked disposal or disclosed retention of offline backups,
+external destinations and other derived copies. The
+[design inventory and implementation handoff](https://github.com/JamesHWade/graft/blob/main/adr/0006-retire-forgotten-generations-before-restore.md)
+identify those owners and unresolved guarantees.


### PR DESCRIPTION
Related to #48; builds on #47 / PR #57.

## Summary

An older Graft backup contains the original and corrected versions of a record after a Reader chooses Forget. This proposal retires the affected Reader's store generation in an independent host journal before cleanup, then admits only a certified replacement and its verified backup. It inventories Graft authority, projections, OKF, detached copies, checkpoints, external content and backups, and assigns the remaining Graft, Rill and storage implementation tasks.

The explicit design tradeoff is that **every old snapshot for the affected Reader becomes unavailable**, including references to surviving records. The replacement uses a new store UUID; old receipts are never rewritten. The second Reader retains its existing store and evidence. This tradeoff is proposed for review, not added to supported Graft behavior.

The offline proof uses real Graft databases, accepted corrections, pinned history and receipts. A test-only host journal exercises exact approval, dependency selection, interruptions and retries, missing/modified backup metadata, invalid replacement rejection, fresh workers and in-flight result withholding. A retained offline backup deliberately remains readable through raw file access while the host restore gate rejects it. Stand-in files model local derived-copy cleanup; no production purge, authentication, durable journal or migration API is introduced.

## Verification

- `devtools::test(filter = "^forget-restore")`: 105 expectations passed, no failures, warnings or skips. Regressions cover rejected/abandoned candidate cleanup, missing or changed surviving history, private payload changes, metadata copies without selected IDs, stale heads with rebuilt projections, and loading the development checkout in a fresh worker.
- All 13 CI checks pass at `453dc74`, including full package checks on macOS, Linux and Windows, compatibility and pkgdown. Linux reports 2,477 passing expectations with four optional-CLI skips; Windows reports 2,474 with those four skips and one platform skip. Linux retains the pre-existing `uv-setuptools` temporary-lock NOTE; Windows reports Status: OK.
- Air, Jarl and `git diff --check` passed. The new guide was inspected in a browser.
- Fresh automated review completed on `453dc74` with no new findings; all five review threads are addressed and resolved.

Issue #48 remains open for review and the bounded implementation handoff. Rill production erasure/backup recovery, actual derived-copy disposal, external retention and physical storage erasure are not established by this proof.

